### PR TITLE
Add Claude Code OAuth token support to Devsy workflow

### DIFF
--- a/.github/workflows/devsy.yml
+++ b/.github/workflows/devsy.yml
@@ -80,6 +80,7 @@ jobs:
 
           # === API Keys ===
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Alternative AI providers (uncomment if using):
           # aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Added `claude_code_oauth_token` parameter to the Devsy GitHub Action workflow
- This enables OAuth authentication for Claude Code Max Plan users
- OAuth tokens provide flat pricing for Max Plan subscribers vs per-token billing with API keys

## Changes
- Added `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` to `.github/workflows/devsy.yml`

## Configuration
To use this feature:
1. Run `claude auth` in Claude Code CLI to obtain OAuth token
2. Add the token as a repository secret named `CLAUDE_CODE_OAUTH_TOKEN`
3. The workflow will automatically use OAuth when the secret is configured