### PR TITLE
test(provider): pin background=True contract at create_provider factory

### DIFF
--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -92,3 +92,51 @@ def test_default_config_includes_code_interpreter_and_omits_max_tool_calls() -> 
         f"code_interpreter tool must carry container={{type: auto}} "
         f"(OpenAI API requirement), got: {code_interp_tool}"
     )
+
+
+def test_create_provider_sets_background_for_deep_research_model() -> None:
+    """Regression: create_provider must set background=True when the mode
+    pins a deep-research model. Previously only covered end-to-end via
+    test_oai_background.py — this pins the contract at the factory."""
+    from types import SimpleNamespace
+
+    from thoth.config import ConfigManager
+    from thoth.providers import create_provider
+
+    config = cast(
+        ConfigManager,
+        SimpleNamespace(
+            data={"providers": {"openai": {"api_key": "sk-test-deep-research-factory"}}}
+        ),
+    )
+    mode_config: dict[str, Any] = {"model": "o3-deep-research"}
+
+    provider = create_provider(
+        "openai",
+        config,
+        mode_config=mode_config,
+    )
+    # provider.config is the mutated provider_config dict passed to the constructor;
+    # background=True is set when is_background_mode(provider_config) is True.
+    assert provider.config.get("background") is True
+
+
+def test_create_provider_no_background_for_plain_model() -> None:
+    """Inverse: a plain (non-deep-research) model does NOT get background=True."""
+    from types import SimpleNamespace
+
+    from thoth.config import ConfigManager
+    from thoth.providers import create_provider
+
+    config = cast(
+        ConfigManager,
+        SimpleNamespace(data={"providers": {"openai": {"api_key": "sk-test-plain-factory"}}}),
+    )
+    mode_config: dict[str, Any] = {"model": "o3"}
+
+    provider = create_provider(
+        "openai",
+        config,
+        mode_config=mode_config,
+    )
+    assert provider.config.get("background", False) is False


### PR DESCRIPTION
## Summary

Recovers a stashed test contribution that was orphaned when its source branch (\`feat/thoth-test-ergonomics\`) was deleted without ever opening a PR. The work was sitting only in a local stash, with no remote backup.

Adds two regression tests in \`tests/test_provider_config.py\` pinning the \`create_provider()\` factory contract:

- **\`test_create_provider_sets_background_for_deep_research_model\`** — asserts \`create_provider()\` sets \`background=True\` when the mode pins a deep-research model (e.g. \`o3-deep-research\`). Previously this was only covered end-to-end via \`test_oai_background.py\`; the new test pins it at the factory.
- **\`test_create_provider_no_background_for_plain_model\`** — inverse: a plain (non-deep-research) model must NOT carry \`background=True\`.

Implements step 4.1 of \`docs/superpowers/plans/2026-04-24-p13-p11-followup.md\`. The planned tests were specced but never landed; this fills the gap.

## Verification

- \`uv run pytest tests/test_provider_config.py -v\` → 5/5 pass (3 pre-existing + 2 new)
- \`uv run ruff format --check / check\` → clean
- \`uv run ty check\` → clean

## Test plan

- [ ] CI green on \`tests/test_provider_config.py\`
- [ ] No regression in the wider pytest suite (\`uv run pytest tests/\`)