### PR TITLE
feat: P18 — Immediate vs Background (kind, runtime mismatch, streaming, cancel) for v3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,9 @@ jobs:
       - name: yamllint
         run: uvx yamllint -c .yamllint .
       - name: codespell
-        run: >
-          uvx codespell
-          --skip=".git,.venv,htmlcov,uv.lock,bun.lock,requirements.txt,archive,planning,research"
-          --ignore-words-list="thoth,perplexity,sonar,pplx,openai,hel"
-          .
+        # Config (skip + ignore-words-list) lives in pyproject.toml under
+        # [tool.codespell] — shared with lefthook so they can't drift.
+        run: uvx codespell .
       - name: bandit
         run: uvx bandit -r src/ -ll
       - name: editorconfig-checker

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,34 @@
+---
+# P18 Phase I: nightly real-API contract tests.
+#
+# Runs `pytest -m extended` which exercises every entry in KNOWN_MODELS
+# against live provider APIs to detect drift between thoth's declared
+# `kind` and what the upstream API actually does. Gated on OPENAI_API_KEY
+# being set as a repo secret. The job is informational — failures notify
+# the team but do NOT block PR merges.
+
+name: Extended Contract Tests (nightly)
+
+"on":
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  extended:
+    name: pytest -m extended
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
+      - name: Run extended contract tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: uv run pytest -m extended -v
+        continue-on-error: true

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1,3 +1,83 @@
+## [ ] Project P20: Extended Real-API Workflow Coverage — Mirror Mock Contracts
+
+**Goal**: Expand the `@pytest.mark.extended` real-API suite from model-kind smoke checks into periodic workflow coverage that mirrors the important mock/thoth_test contracts. These tests stay out of default pytest, run manually or nightly, and answer: "Does the real OpenAI runtime still honor the immediate/background split, output sinks, file output semantics, status/cancel behavior, and option forwarding?"
+
+**Primary dependency**: P18 immediate-vs-background path split and `tests/extended/test_model_kind_runtime.py`.
+**Primary files**:
+- Add: `tests/extended/test_real_api_workflows.py`
+- Modify: `tests/extended/conftest.py` if shared real-API helpers are split out
+- Modify: `pyproject.toml` only if adding a narrower marker such as `extended_slow`
+- Modify: `justfile` only if adding a helper command such as `just test-extended-workflows`
+
+**Scope rule**: mirror the mock contracts at the workflow boundary, but keep assertions stable for real LLM output. Assert non-empty output, file creation/non-creation, metadata presence/absence, CLI status text, operation state, secret masking, and checkpoint/output paths. Do **not** assert deterministic prose.
+
+**Cost and safety gates**
+- All tests use `@pytest.mark.extended`; default `uv run pytest` must still deselect them.
+- Tests that complete real background deep-research jobs should also use a second marker or env gate, e.g. `@pytest.mark.extended_slow` or `THOTH_EXTENDED_SLOW=1`.
+- Use tiny prompts and isolated temp output/config/state directories.
+- Prefer `--async` + `cancel` for background state-machine checks where completion is not required.
+- Always assert CLI-provided API keys are not printed in stdout/stderr.
+- Cancel any still-running background job in `finally`.
+
+### Test Design
+
+**Shared helpers**
+- [ ] [P20-TS01] Add an extended-test CLI runner fixture that:
+  - skips unless `OPENAI_API_KEY` is set;
+  - sets isolated `HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`;
+  - runs `python -m thoth ...` or `uv run thoth ...` with a bounded timeout;
+  - returns `exit_code`, `stdout`, `stderr`, and temp output paths;
+  - scrubs secrets from captured failure output.
+- [ ] [P20-TS02] Add helper assertions for real-output files:
+  - `assert_nonempty_file(path)`;
+  - `assert_no_default_result_files(tmp_path, provider="openai")`;
+  - `assert_metadata_present(path, prompt_fragment, mode, provider)`;
+  - `assert_metadata_absent(path)`;
+  - `assert_secret_not_leaked(stdout, stderr, secret)`.
+
+**Immediate real-API workflows, mirror mock streaming/output-sink tests**
+- [ ] [P20-TS03] `thoth ask "extended immediate stdout" --mode thinking --provider openai` streams non-empty stdout, exits 0, creates no default result file, emits no background completion/status/resume hints.
+- [ ] [P20-TS04] `thoth ask "extended immediate file" --mode thinking --provider openai --out answer.md` writes a non-empty `answer.md`, suppresses streamed stdout, and creates no default result file.
+- [ ] [P20-TS05] `--out -,answer.md` tees real streamed output to stdout and file; both are non-empty.
+- [ ] [P20-TS06] repeatable `--out - --out answer.md` behaves like the comma-list tee form.
+- [ ] [P20-TS07] `--append` appends instead of truncating: run twice to the same file and assert file size grows and the first run's content prefix is preserved.
+- [ ] [P20-TS08] bare prompt form supports leading `--out`: `thoth --out answer.md --provider openai "extended bare leading"`.
+- [ ] [P20-TS09] bare prompt form supports trailing `--out`: `thoth "extended bare trailing" --provider openai --out answer.md`.
+- [ ] [P20-TS10] immediate `--output-dir DIR` alone does not create a background-style result file.
+- [ ] [P20-TS11] immediate `--quiet` still streams the answer but suppresses progress/background-only UI.
+
+**Background real-API workflows, mirror BG-* and file-output tests**
+- [ ] [P20-TS12] `thoth deep_research "extended bg async" --provider openai --async` returns an operation ID, writes a checkpoint, and `thoth status <op-id>` reports a valid queued/running/completed state; cancel if still active.
+- [ ] [P20-TS13] `thoth cancel <op-id>` against a running real OpenAI background job marks the checkpoint cancelled and exits 0.
+- [ ] [P20-TS14] gated slow test: synchronous `thoth deep_research "extended bg complete" --provider openai --output-dir DIR` eventually exits 0 and writes a non-empty OpenAI result file with metadata.
+- [ ] [P20-TS15] `--project extended-project` writes under `base_output_dir/extended-project/` and reports the project output location.
+- [ ] [P20-TS16] `--input-file input.md` records `input_files:` metadata in the generated result.
+- [ ] [P20-TS17] `--no-metadata` writes a non-empty result file without YAML metadata, `operation_id:`, or the `### Prompt` section.
+- [ ] [P20-TS18] `--quiet` still writes the result file while suppressing `Research completed`, `Results saved to:`, progress text, and status/list hints as appropriate for quiet background mode.
+- [ ] [P20-TS19] `--prompt-file prompt.txt` uses the prompt file; assert metadata or output path reflects the file prompt enough to prove the prompt source was honored.
+- [ ] [P20-TS20] `--prompt-file -` accepts stdin in a subprocess run and completes or submits correctly.
+- [ ] [P20-TS21] `--api-key-openai sk-...` works without `OPENAI_API_KEY` in the environment and does not leak the key in stdout/stderr.
+
+**Chained and multi-output workflows**
+- [ ] [P20-TS22] gated slow test: `--auto` chain in one project. Run a first background mode that writes an output, then run the next background mode with `--auto --project same-project`; assert the second operation records the previous output under `input_files:`.
+- [ ] [P20-TS23] `--auto` with no previous project output prints the warning and does not crash.
+- [ ] [P20-TS24] `--combined` real-provider test remains skipped until at least two real providers are operational, or until a mixed real+mock policy is explicitly accepted. When enabled, assert separate provider outputs plus a combined report are written and the combined report contains provider section headers.
+- [ ] [P20-TS25] no `--combined` means no combined report is written, even when multiple provider outputs exist.
+
+**Real provider runtime contract expansion**
+- [ ] [P20-TS26] Extend `tests/extended/test_model_kind_runtime.py` so every `KNOWN_MODELS` entry also proves the provider path used matches the declared kind:
+  - immediate models exercise `provider.stream()` and produce at least one text delta;
+  - background models exercise `submit()` + `check_status()` and are cancellable when still running.
+- [ ] [P20-TS27] Add a mismatch defense test with real provider construction but no HTTP call: immediate-declared deep-research model raises `ModeKindMismatchError` before any request is made.
+
+### Acceptance Criteria
+- `uv run pytest -q` still reports the extended workflow tests as deselected by default.
+- `uv run pytest -m extended tests/extended/test_real_api_workflows.py -v` runs the fast real-API workflow tests when `OPENAI_API_KEY` is present.
+- Slow/costly background completion and `--auto` chain tests are separately gated and documented in their skip reasons.
+- Every immediate mock workflow with `--out`, tee, append, bare prompt, quiet, and no default result file has a corresponding real-API extended test.
+- Every background mock workflow for project, input file, no metadata, quiet, prompt-file, stdin, CLI API key, status/cancel, and output-file creation has a corresponding real-API extended test or a documented provider-availability skip.
+- `--combined` and `--auto` are explicitly covered by future extended tests, not just by mock/integration tests.
+
 ## [ ] Project P18: Immediate vs Background — Explicit `kind`, Runtime Mismatch, Path Split, Streaming, Cancel (v3.1.0)
 
 **Primary spec**: `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md` (decisions Q1–Q12 §4, architecture §5, rollout §6, testing strategy §7, cross-project coordination §8, risks §9, **§11 reevaluation log 2026-04-27**)
@@ -10,6 +90,8 @@
 **Coordination with shipped P16 (v3.0.0 — landed in `f8b62f2`)**: `thoth ask` is the canonical scripted research entrypoint and inherits `_research_options`. P18's path split happens **inside** the existing dispatch — `thoth ask "..." --mode <immediate-mode>` automatically gets streaming behavior. `thoth ask --json` already implements the kind-aware split (Option E in `cli_subcommands/ask.py:158-231`); P18 brings the same split to the human-readable path. No PR2/PR3 changes required.
 
 **Follow-up tracked separately**: requiring `kind` on user-defined modes lands as **warn-once** in P18; the **error** form is deferred to a future P19 / **v4.0.0** breakage window (when the next major opens — v3.0.0 is already locked by P16 breakages).
+
+**Future test-hardening project**: add dedicated background-mode regression coverage for `--combined` and `--auto`. P18 now pins the immediate/background split and the core background options, but `--combined` multi-provider report generation and `--auto` cross-run input chaining still need explicit tests under the new contract.
 
 **Out of Scope**
 - Renaming mode `thinking` (kept — `kind` carries the execution-model semantics now; further renaming would collide with PR2's `ask` subcommand)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,68 @@ thoth "prompt" --no-metadata
 thoth "prompt" --quiet
 ```
 
+### Streaming output for immediate modes (P18, v3.1.0+)
+
+Immediate-kind modes (`default`, `thinking`, `clarification`) stream tokens
+to stdout as they arrive — no progress bar, no operation-ID echo, no
+resume hint. Use `--out` to redirect or tee:
+
+```bash
+# Stream to stdout (default)
+thoth ask "what is X" --mode thinking
+
+# Write to a file (truncate)
+thoth ask "what is X" --mode thinking --out answer.md
+
+# Tee to stdout AND a file
+thoth ask "what is X" --mode thinking --out -,answer.md
+
+# Append instead of truncating
+thoth ask "what is X" --mode thinking --out answer.md --append
+```
+
+Background-kind modes (e.g. `deep_research`, `quick_research`,
+`exploration`, etc.) continue to use `--project` / `--output-dir` for
+persistent output. `--out` is currently immediate-only.
+
+### Cancelling a running operation
+
+```bash
+# Cancel an in-flight background operation by ID
+thoth cancel a1b2c3d4-...
+
+# Returns exit 6 if the operation isn't found; 0 otherwise.
+# JSON envelope available:
+thoth cancel a1b2c3d4-... --json
+```
+
+`thoth cancel` calls the provider's upstream cancel endpoint where
+supported (OpenAI Responses API), then marks the local checkpoint as
+cancelled. Providers without upstream cancel (e.g., Perplexity at the
+time of writing) have the local checkpoint marked cancelled but the
+upstream job runs to completion.
+
+### Filtering modes by execution kind (P18)
+
+Each mode is declared as `kind = "immediate"` (synchronous, streaming)
+or `kind = "background"` (async, polling-loop). User-defined modes in
+`~/.config/thoth/config.toml` should declare `kind` explicitly; missing
+`kind` warns once and falls back to a substring heuristic on the model
+name.
+
+```bash
+# Show only immediate-kind modes
+thoth modes --kind immediate
+
+# Show only background-kind modes
+thoth modes --kind background
+```
+
+A misconfigured mode (e.g., declared `immediate` but using a
+deep-research model) raises `ModeKindMismatchError` at submit time
+with a config-edit suggestion — before any HTTP call hits the
+provider.
+
 ### Interactive Mode
 ```bash
 # Enter interactive prompt mode with enhanced UI

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ thoth "prompt" --quiet
 
 Immediate-kind modes (`default`, `thinking`, `clarification`) stream tokens
 to stdout as they arrive — no progress bar, no operation-ID echo, no
-resume hint. Use `--out` to redirect or tee:
+resume hint, and no default result file. Use `--out` to redirect or tee:
 
 ```bash
 # Stream to stdout (default)
@@ -175,6 +175,7 @@ thoth ask "what is X" --mode thinking
 
 # Write to a file (truncate)
 thoth ask "what is X" --mode thinking --out answer.md
+thoth --out answer.md --provider mock "what is X"
 
 # Tee to stdout AND a file
 thoth ask "what is X" --mode thinking --out -,answer.md

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,6 +1,16 @@
+// Self-contained Conventional Commits config. We do NOT extend
+// `@commitlint/config-conventional` — that would force every git worktree
+// to run `npm install` before its first commit (commitlint's `extends`
+// resolver looks in `<cwd>/node_modules`, which is per-worktree). The
+// rules below mirror the conventional-commits subset we actually enforce.
+//
+// Effect: `bunx commitlint --edit {1}` works with NO local node_modules
+// and NO project-level package.json.
+
 export default {
-  extends: ['@commitlint/config-conventional'],
   rules: {
+    'type-empty': [2, 'never'],
+    'type-case': [2, 'always', 'lower-case'],
     'type-enum': [
       2,
       'always',
@@ -18,6 +28,10 @@ export default {
         'revert',
       ],
     ],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
     'header-max-length': [2, 'always', 100],
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [2, 'always'],
   },
 };

--- a/justfile
+++ b/justfile
@@ -119,6 +119,13 @@ test:
 test-serial:
     uv run pytest tests/ -v
 
+# Run extended (real-API) contract tests. Gated by `pytest -m extended`;
+# requires OPENAI_API_KEY (Perplexity skipped until provider lands). P18
+# Phase I — runs nightly via .github/workflows/extended.yml.
+[group: 'testing']
+test-extended:
+    uv run pytest -m extended -v
+
 # Run tests skipping interactive mode (fast, CI-safe)
 [group: 'testing']
 test-skip-interactive:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -72,11 +72,12 @@ pre-commit:
     gitleaks:
       run: ./scripts/check-gitleaks.sh staged
 
+    # Config (skip + ignore-words-list) lives in pyproject.toml under
+    # [tool.codespell] so lefthook + CI pick up the same list. Don't
+    # duplicate flags here.
     codespell:
       glob: "*.{py,md}"
-      run: |
-        uvx codespell --skip=".git,.venv,htmlcov,uv.lock,requirements.txt,archive,planning,research" \
-          --ignore-words-list="thoth,perplexity,sonar,pplx,openai,hel" {staged_files}
+      run: uvx codespell {staged_files}
 
     test:
       glob: "*.py"
@@ -98,13 +99,11 @@ pre-push:
     # at push time, not just staged files. Catches typos / YAML issues
     # introduced in commits where the affected file is not staged again
     # later (and survives LEFTHOOK=0 WIP commits that bypass pre-commit).
-    # Same flag set as .github/workflows/ci.yml's Hygiene job.
+    # codespell config is shared via pyproject.toml [tool.codespell];
+    # yamllint config is .yamllint. Both files are also consumed by
+    # .github/workflows/ci.yml's Hygiene job.
     codespell-full:
-      run: |
-        uvx codespell \
-          --skip=".git,.venv,htmlcov,uv.lock,bun.lock,requirements.txt,archive,planning,research,node_modules" \
-          --ignore-words-list="thoth,perplexity,sonar,pplx,openai,hel" \
-          .
+      run: uvx codespell .
 
     yamllint-full:
       run: uvx yamllint -c .yamllint .

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -93,3 +93,18 @@ pre-push:
 
     gitleaks:
       run: ./scripts/check-gitleaks.sh full
+
+    # Mirror CI's Hygiene job: codespell + yamllint over the WHOLE repo
+    # at push time, not just staged files. Catches typos / YAML issues
+    # introduced in commits where the affected file is not staged again
+    # later (and survives LEFTHOOK=0 WIP commits that bypass pre-commit).
+    # Same flag set as .github/workflows/ci.yml's Hygiene job.
+    codespell-full:
+      run: |
+        uvx codespell \
+          --skip=".git,.venv,htmlcov,uv.lock,bun.lock,requirements.txt,archive,planning,research,node_modules" \
+          --ignore-words-list="thoth,perplexity,sonar,pplx,openai,hel" \
+          .
+
+    yamllint-full:
+      run: uvx yamllint -c .yamllint .

--- a/package.json
+++ b/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "thoth-dev-tooling",
-  "private": true,
-  "description": "Node-based dev tooling for thoth (commitlint only).",
-  "devDependencies": {
-    "@commitlint/cli": "^19.5.0",
-    "@commitlint/config-conventional": "^19.5.0"
-  }
-}

--- a/planning/p18-call-site-audit.md
+++ b/planning/p18-call-site-audit.md
@@ -1,0 +1,62 @@
+# P18 — `is_background_*` call-site audit
+
+**Generated:** 2026-04-27 during Phase A of P18 implementation.
+**Tracked:** `PROJECTS.md` § P18-T03c.
+**Spec reference:** `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md` §10 acceptance gate.
+
+## Purpose
+
+P18 introduces `mode_kind(cfg)` as the canonical resolver for a mode's
+execution kind. The two pre-existing helpers split into distinct roles:
+
+| Helper | Role after P18 |
+|---|---|
+| `mode_kind(mode_config)` | **NEW.** Canonical resolution path. Reads declared `kind`; falls back through `async` (deprecated) and `is_background_model(model)` (substring) for legacy/user modes. |
+| `is_background_mode(mode_config)` | Thin wrapper over `mode_kind(...) == "background"`. Kept for compat. **Removed in v4.0.0.** |
+| `is_background_model(model)` | **Unchanged.** Model-level helper for "what does this provider require for this model?". Used inside the runtime mismatch check and `should_show_spinner`. **Stays in v4.0.0.** |
+
+This document enumerates every existing call site, classifies each, and
+records the disposition for the Phase A → C migration.
+
+## Call-site inventory (post-Phase A)
+
+`grep -rn "is_background_mode\|is_background_model" src/thoth/` on `feat/p18-immediate-vs-background` after Phase A:
+
+| # | Call site | Helper used | Today | Disposition | Phase |
+|---|---|---|---|---|---|
+| 1 | `config.py:136` | `is_background_model` def | model-level helper | **Unchanged.** Used inside runtime mismatch check + spinner gate. | (no change) |
+| 2 | `config.py:189` | `mode_kind` def *(NEW in Phase A)* | n/a | **Added.** Canonical resolver. | A (done) |
+| 3 | `config.py:218` | `is_background_mode` def | mode-level wrapper | **Becomes thin wrapper over `mode_kind`.** Done in Phase A. | A (done) |
+| 4 | `interactive_picker.py:35,44` | `is_background_model(model)` | filters `--pick-model` candidates ("immediate models only") | **Migrate to `mode_kind(mode_cfg) == "immediate"`** if mode_cfg in scope; else stay as model-level helper if only `model` is available. | C |
+| 5 | `cli.py:284` | `is_background_model(model_name)` | gates a CLI behavior on the resolved model | **Migrate to `mode_kind(mode_cfg) == "background"`** if mode_cfg in scope at this call site; else keep as model-level helper. | C |
+| 6 | `progress.py:33` | `is_background_model(model)` | spinner gate | **Unchanged at the helper level.** Phase C extends `should_show_spinner` to **also** suppress the Progress bar for immediate runs (gate becomes mode-aware via a new `mode_cfg` parameter). | C |
+| 7 | `modes_cmd.py:51` | (was) `is_background_mode(cfg)` | derives display kind for `thoth modes` table | **Migrated to read `cfg["kind"]` first, fall back via `mode_kind`.** Done in Phase A. | A (done) |
+| 8 | `providers/openai.py:176` | `is_background_model(self.model)` | branches submission tools (`web_search_preview`, `code_interpreter`) on whether model is deep-research | **Unchanged.** Model-level helper — provider's internal taxonomy. | (no change) |
+| 9 | `providers/openai.py:183` | `is_background_model(self.model)` | sets `use_background` request param | **Unchanged.** Same reason as #8. Could optionally read `self.config.get("kind") == "background"` after Phase B threads kind through; not load-bearing for this PR. | (no change) |
+| 10 | `providers/__init__.py:111` (`create_provider`) | `is_background_mode(provider_config)` | sets `provider_config["background"] = True` for openai when mode is background | **Migrate to `mode_kind(provider_config) == "background"`** so the resolution is explicit and uses the declared `kind` first. | B |
+| 11 | `cli_subcommands/ask.py:171,176` | `is_background_mode(mode_config)` | Option E `--json` envelope decision: background → submit envelope; immediate → snapshot from checkpoint | **Migrate to `mode_kind(mode_config) == "background"`**. Behavior unchanged. | C |
+
+## Migration policy
+
+- **Resolution-path callers** (those holding a `mode_config` and asking "is this mode background?") **migrate to `mode_kind(cfg)`** so they pick up the explicit `kind` field first.
+- **Model-level callers** (those holding only a `model` string, not a `mode_config`) **keep `is_background_model(model)`**. The substring rule is correct as the API-enforcement boundary inside the runtime mismatch check (Phase B) and the spinner gate (Phase C).
+- **No new substring-only resolution** introduced anywhere. All new code uses `mode_kind(cfg)`.
+
+## Phase B / C migration target
+
+Post-Phases B + C, `grep -rnE 'is_background_(mode|model)' src/thoth/` should return only:
+- `config.py` (the two defs + the thin `is_background_mode` wrapper)
+- `progress.py:33` (model-level spinner gate; unchanged)
+- `providers/openai.py:176, 183` (model-level provider taxonomy; unchanged)
+- The new runtime mismatch check inside `OpenAIProvider._validate_kind_for_model` (Phase B)
+
+That's the v3.1.0 acceptance gate per spec §10.
+
+## v4.0.0 (future P19) follow-up
+
+- Drop `is_background_mode(cfg)` thin wrapper. Callers migrate to `mode_kind(cfg) == "background"`.
+- Drop `async: bool` legacy field. `mode_kind` removes the deprecation branch.
+- Required-kind error for user modes (was: warn-once in Phase H).
+
+The model-level `is_background_model(model)` helper survives — it remains the
+correct heuristic for "this OpenAI model requires background submission".

--- a/planning/p18-cancel-research.md
+++ b/planning/p18-cancel-research.md
@@ -1,0 +1,199 @@
+# P18 Phase F — Cancel API research per provider
+
+**Generated:** 2026-04-28 during Phase F of P18 implementation.
+**Tracked:** `PROJECTS.md` § P18 tasks T18 / T19 / T20.
+**Spec reference:** `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md` §1 + §4 Q9.
+
+## Purpose
+
+P18 introduces an optional `provider.cancel(job_id)` capability on
+`ResearchProvider`. Each upstream provider has its own cancellation
+semantics (or lack thereof). Before implementing per-provider, we need to
+know what each API actually exposes so we can map it to a uniform thoth
+contract. Providers without upstream cancel support raise
+`NotImplementedError` from the base — the `thoth cancel` CLI catches it and
+reports "upstream cancel not supported, local checkpoint marked cancelled".
+
+## Uniform contract (re: how thoth callers see cancel)
+
+```python
+# providers/base.py
+async def cancel(self, job_id: str) -> dict[str, Any]:
+    """Best-effort cancel of an in-flight job. Returns final status dict.
+
+    Status keys mirror `check_status`:
+      {"status": "cancelled", "error": <str>}      — upstream confirmed cancelled
+      {"status": "completed", "progress": 1.0}     — finished before cancel landed
+      {"status": "permanent_error", "error": ...}  — cancel itself failed
+    """
+```
+
+`thoth cancel <op-id>` invokes this for each non-completed provider on the
+operation, swallowing `NotImplementedError` (to mark only local checkpoint),
+and updates the operation's checkpoint to `cancelled` regardless.
+
+---
+
+## OpenAI — confirmed supported
+
+**Endpoint:** `POST /v1/responses/{response_id}/cancel`
+**SDK signature:** `client.responses.cancel(response_id) -> Response`
+(both sync and async clients)
+
+**When valid:** Only background-mode responses (created with
+`background=True`). Immediate/synchronous responses have already returned
+content by the time the SDK call resolves; there is nothing to cancel.
+
+**Accepted source states:**
+- `queued` — cancel succeeds; final state `cancelled`
+- `in_progress` — cancel succeeds; final state `cancelled`
+- `completed` — cancel call is a no-op; final state stays `completed`
+  (no error)
+- `failed`, `incomplete`, `cancelled` — cancel call is a no-op
+
+**Returned status string:** the response's `.status` field becomes
+`"cancelled"`. The full Response object is returned so we can read it.
+
+**Billing:** OpenAI bills for tokens generated up to the cancel point.
+Cancellation does NOT refund billing. This is fine for our use case
+(user wants to stop, not erase) but worth documenting in user-facing help.
+
+**Implementation plan for `OpenAIProvider.cancel`:**
+
+```python
+async def cancel(self, job_id: str) -> dict[str, Any]:
+    if job_id not in self.jobs:
+        # Reattach lazily — cancel may be invoked from `thoth cancel` after
+        # a fresh process start where self.jobs is empty.
+        try:
+            await self.reconnect(job_id)
+        except Exception as e:
+            return {"status": "permanent_error", "error": f"reconnect failed: {e}"}
+    try:
+        response = await self.client.responses.cancel(job_id)
+        if hasattr(response, "status") and response.status == "completed":
+            return {"status": "completed", "progress": 1.0}
+        return {"status": "cancelled", "error": "Response was cancelled"}
+    except (openai.APIError, Exception) as e:
+        return {
+            "status": "permanent_error",
+            "error": str(e),
+            "error_class": type(e).__name__,
+        }
+```
+
+**Doc URLs (verified during research):**
+- `https://platform.openai.com/docs/api-reference/responses` (cancel
+  endpoint section)
+- `https://cookbook.openai.com/examples/deep_research_api/introduction_to_deep_research_api`
+  (operational guide for background submissions)
+
+---
+
+## Perplexity Sonar — needs verification, likely orphan-only
+
+**Status:** **Not yet implemented in thoth** (`PerplexityProvider.submit`
+raises NotImplementedError; the provider exists only for `thoth providers
+models` listing). Cancel research is forward-compat for when the provider
+lands.
+
+**API:** Perplexity exposes `sonar-deep-research` via their async-friendly
+chat-completions endpoint. The async submission flow returns a
+`request_id` you poll. Documentation as of 2026-04 describes:
+- `POST /async/chat/completions` — submit
+- `GET /async/chat/completions/{request_id}` — poll
+
+**Cancel endpoint:** **Not documented** at the time of this research.
+There is no `DELETE` or `POST .../cancel` endpoint listed in the public
+docs.
+
+**Mapping to thoth contract:**
+
+If verification confirms there is no upstream cancel:
+
+```python
+async def cancel(self, job_id: str) -> dict[str, Any]:
+    # Perplexity does not expose upstream cancel. Drop our local job-id
+    # tracking (so we stop polling) and return cancelled. The upstream
+    # request will run to completion and bill normally; the user has
+    # accepted that by issuing `thoth cancel`.
+    self.jobs.pop(job_id, None)
+    return {
+        "status": "cancelled",
+        "error": "Perplexity does not support upstream cancel; "
+                 "request will complete and bill normally.",
+    }
+```
+
+**Alternative (recommended):** Leave `PerplexityProvider.cancel` as the
+inherited `NotImplementedError` and let the `thoth cancel` CLI display the
+"upstream cancel not supported" message. That communicates the limitation
+honestly rather than papering over it with a half-truth.
+
+**Recommendation for v3.1.0:** Leave inherited NotImplementedError. When
+the provider's `submit()` lands, revisit cancel based on then-current
+docs.
+
+**Doc URLs to re-verify before any implementation:**
+- `https://docs.perplexity.ai/getting-started/models/models/sonar-deep-research`
+- `https://docs.perplexity.ai/guides/chat-completions-guide`
+- `https://docs.perplexity.ai/api-reference/` (if exists at that path)
+
+---
+
+## Gemini Deep Research — needs verification
+
+**Status:** **Not yet implemented in thoth.** The provider scaffold is
+referenced in `planning/references.md` but does not exist as a module.
+
+**API:** Gemini exposes deep-research via an "Interactions API" at
+`/v1beta/interactions`. The pattern is session-based: create an
+interaction, query it, the model emits intermediate research artifacts
+asynchronously, you poll for completion.
+
+**Cancel endpoint:** Not explicitly documented as of 2026-04. Session
+abandonment (closing the client / not polling) is the implicit cancel.
+
+**Mapping to thoth contract:**
+
+Likely the same recommendation as Perplexity: leave inherited
+NotImplementedError until the provider's `submit()` lands. Then
+reassess based on the docs at that time.
+
+**Doc URLs to re-verify before any implementation:**
+- `https://ai.google.dev/gemini-api/docs/deep-research`
+- `https://ai.google.dev/gemini-api/docs/interactions`
+- `https://ai.google.dev/gemini-api/docs/gemini-for-research`
+
+---
+
+## Mock — trivial
+
+`MockProvider.cancel(job_id)` was added alongside the contract in
+`providers/mock.py`. It pops the job from the in-memory `self.jobs` dict
+and returns `{"status": "cancelled", "error": "cancelled by user"}`.
+Used by the `test_provider_cancel.py` hermetic suite and by the
+`test_cancel_subcommand.py` integration cases.
+
+---
+
+## Phase G implementation matrix
+
+| Provider | `cancel()` impl in v3.1.0 | Rationale |
+|---|---|---|
+| `OpenAIProvider` | **Implemented** via `client.responses.cancel` | Only provider with `submit()` currently working; cancel API is well-documented |
+| `MockProvider` | **Implemented** (pop + return cancelled) | Required for hermetic test coverage |
+| `PerplexityProvider` | Inherits `NotImplementedError` | Provider not yet operational; revisit when `submit()` lands |
+| `GeminiProvider` | Not present | Provider doesn't exist yet |
+
+The `thoth cancel` CLI catches `NotImplementedError` and reports
+"upstream cancel not supported" — preserving the user-visible behavior
+contract regardless of which providers eventually grow real cancel
+support.
+
+## Verification deferred
+
+The OpenAI section was confirmed against the SDK source and the public
+API docs in scope of this research. The Perplexity and Gemini sections
+are based on docs as of 2026-04 and may have been augmented since;
+re-verify before ANY non-OpenAI cancel implementation lands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# P18 Phase I: `extended` marker tests hit the real provider APIs (cost +
+# wall-clock). They are gated out of the default suite via `addopts`. Run
+# explicitly with `uv run pytest -m extended` or `just test-extended`.
+markers = [
+    "extended: real-API contract tests; gated, not run by default",
+]
+addopts = "-m 'not extended'"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,10 @@ quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
 
+# Single source of truth for codespell skip + ignore lists. Both
+# lefthook (pre-commit + pre-push) and the CI Hygiene job pick this up
+# automatically by invoking `uvx codespell` with no flag overrides.
+[tool.codespell]
+skip = ".git,.venv,htmlcov,uv.lock,bun.lock,requirements.txt,archive,planning,research,node_modules"
+ignore-words-list = "thoth,perplexity,sonar,pplx,openai,hel"
+

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -423,11 +423,17 @@ def _run_research_default(
     timeout_override: float | None = None,
     model_override: str | None = None,
     ctx_obj=None,
+    out: tuple[str, ...] = (),
+    append: bool = False,
 ) -> None:
     """Execute a research run with the given mode and prompt.
 
     Extracted from the bare-prompt branch of the pre-refactor cli callback.
     Called by ThothGroup.invoke for both mode-positional and bare-prompt paths.
+
+    P18 Phase E: `out`/`append` are forwarded to `run_research` and only
+    consulted by the immediate-kind streaming path. Background runs ignore
+    them today (deferred to a future P18 follow-up).
     """
     app_ctx = _build_app_context(verbose) if ctx_obj is None else ctx_obj
     _result = _thoth_run.run_research(
@@ -447,6 +453,8 @@ def _run_research_default(
         timeout_override=timeout_override,
         ctx=app_ctx,
         model_override=model_override,
+        out_specs=tuple(out or ()),
+        append=append,
     )
     _run_maybe_async(_result)
 
@@ -480,6 +488,8 @@ def cli(
     quiet,
     no_metadata,
     timeout,
+    out,
+    append,
     interactive,
     clarify,
     pick_model,
@@ -514,6 +524,8 @@ def cli(
     ctx.obj["quiet"] = quiet
     ctx.obj["no_metadata"] = no_metadata
     ctx.obj["timeout"] = timeout
+    ctx.obj["out"] = out
+    ctx.obj["append"] = append
     ctx.obj["interactive"] = interactive
     ctx.obj["clarify"] = clarify
     ctx.obj["pick_model"] = pick_model

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -199,6 +199,7 @@ def _extract_fallback_options(args: list[str], opts: dict) -> tuple[list[str], d
         "-c": "config_path",
         "--timeout": "timeout",
         "-T": "timeout",
+        "--out": "out",
     }
 
     def _validate_provider(value: str) -> None:
@@ -234,6 +235,7 @@ def _extract_fallback_options(args: list[str], opts: dict) -> tuple[list[str], d
         "--clarify": "clarify",
         "--pick-model": "pick_model",
         "-M": "pick_model",
+        "--append": "append",
     }
 
     parsed = dict(opts)
@@ -251,7 +253,11 @@ def _extract_fallback_options(args: list[str], opts: dict) -> tuple[list[str], d
             value = args[i + 1]
             if key == "provider":
                 _validate_provider(value)
-            parsed[key] = _coerce_value(arg, key, value)
+            coerced = _coerce_value(arg, key, value)
+            if key == "out":
+                parsed[key] = (*tuple(parsed.get(key) or ()), coerced)
+            else:
+                parsed[key] = coerced
             i += 2
             continue
         if arg in flag_options:
@@ -265,7 +271,11 @@ def _extract_fallback_options(args: list[str], opts: dict) -> tuple[list[str], d
                 value = arg[len(prefix) :]
                 if key == "provider":
                     _validate_provider(value)
-                parsed[key] = _coerce_value(option, key, value)
+                coerced = _coerce_value(option, key, value)
+                if key == "out":
+                    parsed[key] = (*tuple(parsed.get(key) or ()), coerced)
+                else:
+                    parsed[key] = coerced
                 matched_equals = True
                 break
         if matched_equals:
@@ -384,6 +394,8 @@ def _dispatch_click_fallback(
         timeout_override=opts.get("timeout"),
         model_override=model_override,
         ctx_obj=None,
+        out=tuple(opts.get("out") or ()),
+        append=bool(opts.get("append")),
     )
 
 

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -571,6 +571,10 @@ from thoth.cli_subcommands import resume as _resume_mod  # noqa: E402
 
 cli.add_command(_resume_mod.resume)
 
+from thoth.cli_subcommands import cancel as _cancel_mod  # noqa: E402
+
+cli.add_command(_cancel_mod.cancel)
+
 from thoth.cli_subcommands import init as _init_mod  # noqa: E402
 
 cli.add_command(_init_mod.init)

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -281,10 +281,12 @@ def _pick_model_override(mode: str, config: ConfigManager) -> str:
     mode_cfg = config.get_mode_config(mode)
     raw_model = mode_cfg.get("model")
     model_name = raw_model if isinstance(raw_model, str) else None
-    if _thoth_config.is_background_model(model_name):
+    # P18: gate on declared `kind` first (mode_cfg in scope here); falls back
+    # through `mode_kind` to the substring heuristic for legacy user modes.
+    if _thoth_config.mode_kind(mode_cfg) == "background":
         raise click.BadParameter(
-            "--pick-model is only supported for quick (non-deep-research) modes. "
-            f"Mode '{mode}' uses {model_name}."
+            "--pick-model is only supported for modes with kind='immediate'. "
+            f"Mode '{mode}' uses {model_name} (kind='background')."
         )
 
     from thoth.interactive_picker import immediate_models_for_provider

--- a/src/thoth/cli_subcommands/_option_policy.py
+++ b/src/thoth/cli_subcommands/_option_policy.py
@@ -33,6 +33,8 @@ ROOT_OPTION_LABELS: dict[str, str] = {
     "quiet": "--quiet",
     "no_metadata": "--no-metadata",
     "timeout": "--timeout",
+    "out": "--out",
+    "append": "--append",
     "interactive": "--interactive",
     "clarify": "--clarify",
     "pick_model": "--pick-model",

--- a/src/thoth/cli_subcommands/_options.py
+++ b/src/thoth/cli_subcommands/_options.py
@@ -91,7 +91,7 @@ _RESEARCH_OPTIONS: list[tuple[tuple, dict]] = [
         ("--pick-model", "-M", "pick_model"),
         {
             "is_flag": True,
-            "help": "Interactively pick a model (immediate modes only)",
+            "help": "Interactively pick a model (only for modes with kind='immediate')",
         },
     ),
 ]

--- a/src/thoth/cli_subcommands/_options.py
+++ b/src/thoth/cli_subcommands/_options.py
@@ -82,6 +82,24 @@ _RESEARCH_OPTIONS: list[tuple[tuple, dict]] = [
         },
     ),
     (("--timeout", "-T"), {"type": float, "help": "Override request timeout in seconds"}),
+    (
+        ("--out",),
+        {
+            "multiple": True,
+            "help": (
+                "P18: output sink for immediate-mode runs. '-' for stdout (default), "
+                "PATH for file. Repeatable; comma-list also accepted. "
+                "Background modes still use --output-dir / --project."
+            ),
+        },
+    ),
+    (
+        ("--append",),
+        {
+            "is_flag": True,
+            "help": "P18: open --out file in append mode instead of truncating",
+        },
+    ),
     (("--interactive", "-i"), {"is_flag": True, "help": "Enter interactive prompt mode"}),
     (
         ("--clarify",),

--- a/src/thoth/cli_subcommands/ask.py
+++ b/src/thoth/cli_subcommands/ask.py
@@ -252,6 +252,8 @@ def ask(
         no_metadata=effective_no_metadata,
         timeout_override=effective_timeout,
         model_override=None,
+        out=out,
+        append=append,
     )
 
 

--- a/src/thoth/cli_subcommands/ask.py
+++ b/src/thoth/cli_subcommands/ask.py
@@ -36,6 +36,8 @@ _ASK_HONOR = DEFAULT_HONOR | {
     "quiet",
     "no_metadata",
     "timeout",
+    "out",
+    "append",
 }
 
 
@@ -65,6 +67,8 @@ def ask(
     quiet: bool,
     no_metadata: bool,
     timeout: float | None,
+    out: tuple[str, ...],
+    append: bool,
     interactive: bool,
     clarify: bool,
     pick_model: bool,

--- a/src/thoth/cli_subcommands/ask.py
+++ b/src/thoth/cli_subcommands/ask.py
@@ -168,12 +168,14 @@ def ask(
         import io
 
         from thoth.completion.sources import operation_ids
-        from thoth.config import BUILTIN_MODES, is_background_mode
+        from thoth.config import BUILTIN_MODES, mode_kind
         from thoth.json_output import emit_error, emit_json
         from thoth.run import get_resume_snapshot_data
 
         mode_config = BUILTIN_MODES.get(effective_mode, {})
-        is_bg = is_background_mode(mode_config) if mode_config else False
+        # P18: resolution-path migration — `mode_kind(cfg) == "background"`
+        # replaces the legacy `is_background_mode(cfg)` substring branch.
+        is_bg = mode_kind(mode_config) == "background" if mode_config else False
         force_async = is_bg or effective_async
 
         sink = io.StringIO()

--- a/src/thoth/cli_subcommands/cancel.py
+++ b/src/thoth/cli_subcommands/cancel.py
@@ -113,8 +113,8 @@ def cancel(
 
     if not effective_quiet:
         click.echo(f"Cancelling operation {operation_id}...")
-        for name, pres in (result.get("providers") or {}).items():
-            status = pres.get("status", "?")
+        for name, provider_result in (result.get("providers") or {}).items():
+            status = provider_result.get("status", "?")
             if status == "cancelled":
                 click.echo(f"  ✓ {name}: cancelled upstream")
             elif status == "completed":
@@ -124,9 +124,9 @@ def cancel(
                     f"  ⚠ {name}: upstream cancel not supported; local checkpoint marked cancelled"
                 )
             elif status == "skipped":
-                click.echo(f"  - {name}: already {pres.get('reason', 'terminal')}")
+                click.echo(f"  - {name}: already {provider_result.get('reason', 'terminal')}")
             else:
-                click.echo(f"  ✗ {name}: {status} ({pres.get('error', '')})")
+                click.echo(f"  ✗ {name}: {status} ({provider_result.get('error', '')})")
         click.echo(f"Operation {operation_id} marked cancelled.")
     sys.exit(0)
 

--- a/src/thoth/cli_subcommands/cancel.py
+++ b/src/thoth/cli_subcommands/cancel.py
@@ -1,0 +1,134 @@
+"""`thoth cancel OP_ID` Click subcommand.
+
+P18 Phase G. Mirrors the `cli_subcommands/resume.py` pattern. Loads the
+operation from checkpoint, invokes `provider.cancel(job_id)` for each
+non-completed provider, marks the checkpoint cancelled, and exits 0.
+
+For providers without upstream cancel support (`NotImplementedError`), the
+CLI reports "upstream cancel not supported, local checkpoint marked
+cancelled" — the operation is still locally cancelled so `thoth status`
+and `thoth list` reflect that.
+
+Spec: `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md`
+§5.3 + §5.7.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+from thoth.cli_subcommands._option_policy import (
+    DEFAULT_HONOR,
+    inherited_api_keys,
+    validate_inherited_options,
+)
+from thoth.completion.sources import operation_ids as _operation_ids_completer
+
+_CANCEL_HONOR = DEFAULT_HONOR | {
+    "verbose",
+    "quiet",
+    "api_key_openai",
+    "api_key_perplexity",
+    "api_key_mock",
+}
+
+
+@click.command(name="cancel")
+@click.argument("operation_id", metavar="OP_ID", shell_complete=_operation_ids_completer)
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug output")
+@click.option("--config", "-c", "config_path", help="Path to custom config file")
+@click.option("--quiet", "-Q", is_flag=True, help="Minimal output")
+@click.option("--api-key-openai", help="API key for OpenAI provider")
+@click.option("--api-key-perplexity", help="API key for Perplexity provider")
+@click.option("--api-key-mock", help="API key for Mock provider")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON envelope")
+@click.pass_context
+def cancel(
+    ctx: click.Context,
+    operation_id: str,
+    verbose: bool,
+    config_path: str | None,
+    quiet: bool,
+    api_key_openai: str | None,
+    api_key_perplexity: str | None,
+    api_key_mock: str | None,
+    as_json: bool,
+) -> None:
+    """Cancel an in-flight operation by ID.
+
+    Calls `provider.cancel()` upstream where supported; updates the local
+    checkpoint to `cancelled` regardless. Exit codes:
+      0 — operation successfully cancelled (or already terminal)
+      6 — operation not found
+    """
+    validate_inherited_options(ctx, "cancel", _CANCEL_HONOR)
+
+    # Local imports to avoid cli.py → cli_subcommands → cli.py circular.
+    import asyncio
+
+    from thoth.cli import _apply_config_path
+    from thoth.commands import cancel_operation
+    from thoth.config import get_config
+
+    inherited = ctx.obj or {}
+    effective_config = config_path or inherited.get("config_path")
+    effective_quiet = bool(quiet or inherited.get("quiet"))
+    root_api_keys = inherited_api_keys(ctx)
+    cli_api_keys = {
+        "openai": api_key_openai or root_api_keys["openai"],
+        "perplexity": api_key_perplexity or root_api_keys["perplexity"],
+        "mock": api_key_mock or root_api_keys["mock"],
+    }
+
+    _apply_config_path(effective_config)
+    cm = get_config()
+
+    result = asyncio.run(cancel_operation(operation_id, config=cm, cli_api_keys=cli_api_keys))
+
+    if as_json:
+        from thoth.json_output import emit_error, emit_json
+
+        if result["status"] == "not_found":
+            emit_error(
+                "OPERATION_NOT_FOUND",
+                f"Operation {operation_id} not found",
+                {"operation_id": operation_id},
+                exit_code=6,
+            )
+        emit_json(result)
+
+    # Rich rendering
+    if result["status"] == "not_found":
+        click.echo(f"Error: operation {operation_id} not found", err=True)
+        sys.exit(6)
+
+    if result["status"] == "already_terminal":
+        if not effective_quiet:
+            click.echo(
+                f"Operation {operation_id} is already {result['previous']!r}; nothing to cancel."
+            )
+        sys.exit(0)
+
+    if not effective_quiet:
+        click.echo(f"Cancelling operation {operation_id}...")
+        for name, pres in (result.get("providers") or {}).items():
+            status = pres.get("status", "?")
+            if status == "cancelled":
+                click.echo(f"  ✓ {name}: cancelled upstream")
+            elif status == "completed":
+                click.echo(f"  ✓ {name}: completed before cancel landed")
+            elif status == "upstream_unsupported":
+                click.echo(
+                    f"  ⚠ {name}: upstream cancel not supported; local checkpoint marked cancelled"
+                )
+            elif status == "skipped":
+                click.echo(f"  - {name}: already {pres.get('reason', 'terminal')}")
+            else:
+                click.echo(f"  ✗ {name}: {status} ({pres.get('error', '')})")
+        click.echo(f"Operation {operation_id} marked cancelled.")
+    sys.exit(0)
+
+
+__all__ = ["cancel"]

--- a/src/thoth/cli_subcommands/modes.py
+++ b/src/thoth/cli_subcommands/modes.py
@@ -23,6 +23,7 @@ from thoth.cli_subcommands._option_policy import (
     inherited_value,
     validate_inherited_options,
 )
+from thoth.completion.sources import mode_kind as _mode_kind_completer
 from thoth.completion.sources import mode_names as _mode_names_completer
 
 _PASSTHROUGH_CONTEXT = {"ignore_unknown_options": True, "allow_extra_args": True}
@@ -81,6 +82,14 @@ for _flag, _new_form in _LEGACY_FLAG_TO_NEW_FORM.items():
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON envelope")
 @click.option("--source", "source", default="all", help="Filter by source")
+@click.option(
+    "--kind",
+    "kind",
+    type=click.Choice(["immediate", "background"]),
+    default=None,
+    help="Filter by execution kind (P18)",
+    shell_complete=_mode_kind_completer,
+)
 @click.option("--show-secrets", "show_secrets", is_flag=True, help="Reveal masked secrets")
 @click.pass_context
 def modes_list(
@@ -89,6 +98,7 @@ def modes_list(
     name: str | None,
     as_json: bool,
     source: str,
+    kind: str | None,
     show_secrets: bool,
 ) -> None:
     """List research modes."""
@@ -106,6 +116,7 @@ def modes_list(
                 source=source,
                 show_secrets=show_secrets,
                 config_path=config_path,
+                kind=kind,
             )
         )
 
@@ -118,6 +129,8 @@ def modes_list(
         rebuilt.extend(["--name", name])
     if source != "all":
         rebuilt.extend(["--source", source])
+    if kind is not None:
+        rebuilt.extend(["--kind", kind])
     if show_secrets:
         rebuilt.append("--show-secrets")
 

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -732,8 +732,91 @@ def providers_check(config: ConfigManager) -> int:
     return 0
 
 
+async def cancel_operation(
+    op_id: str,
+    *,
+    config: ConfigManager | None = None,
+    cli_api_keys: dict[str, str | None] | None = None,
+) -> dict[str, Any]:
+    """P18 Phase G: cancel a previously-started operation.
+
+    Loads the operation from checkpoint, calls `provider.cancel(job_id)` for
+    each non-completed provider on the operation, updates the checkpoint to
+    `cancelled`, and returns a structured result for the caller to render.
+
+    Returns one of:
+      * {"status": "ok",  "operation_id": ..., "providers": {...}}
+      * {"status": "not_found", "operation_id": ...}              — exit 6
+      * {"status": "already_terminal", "operation_id": ..., "previous": "completed"|"cancelled"|...}
+
+    Catches `NotImplementedError` from providers without upstream cancel
+    support; reports best-effort behavior in `providers[name]` as
+    "upstream cancel not supported". The local checkpoint is marked
+    cancelled regardless.
+    """
+    cm = config if config is not None else get_config()
+    cpm = CheckpointManager(cm)
+    op = await cpm.load(op_id)
+    if op is None:
+        return {"status": "not_found", "operation_id": op_id}
+
+    if op.status in ("completed", "cancelled", "failed"):
+        return {
+            "status": "already_terminal",
+            "operation_id": op_id,
+            "previous": op.status,
+        }
+
+    # Local import to avoid CLI ↔ providers circular at module load.
+    from thoth.providers import create_provider
+
+    per_provider: dict[str, dict[str, Any]] = {}
+    for provider_name, pdata in op.providers.items():
+        if pdata.get("status") in ("completed", "cancelled", "failed"):
+            per_provider[provider_name] = {"status": "skipped", "reason": pdata.get("status")}
+            continue
+        job_id = pdata.get("job_id")
+        if not job_id:
+            per_provider[provider_name] = {"status": "no_job_id"}
+            continue
+        try:
+            mode_config = cm.get_mode_config(op.mode)
+            provider_instance = create_provider(
+                provider_name,
+                cm,
+                cli_api_key=(cli_api_keys or {}).get(provider_name) if cli_api_keys else None,
+                mode_config=mode_config,
+            )
+            cancel_result = await provider_instance.cancel(job_id)
+            per_provider[provider_name] = cancel_result
+            op.providers[provider_name]["status"] = "cancelled"
+        except NotImplementedError as e:
+            per_provider[provider_name] = {
+                "status": "upstream_unsupported",
+                "error": str(e),
+            }
+            op.providers[provider_name]["status"] = "cancelled"
+        except Exception as e:  # noqa: BLE001 — best-effort, swallow and report
+            per_provider[provider_name] = {
+                "status": "permanent_error",
+                "error": str(e),
+                "error_class": type(e).__name__,
+            }
+            op.providers[provider_name]["status"] = "cancelled"
+
+    op.transition_to("cancelled")
+    await cpm.save(op)
+
+    return {
+        "status": "ok",
+        "operation_id": op_id,
+        "providers": per_provider,
+    }
+
+
 __all__ = [
     "CommandHandler",
+    "cancel_operation",
     "get_init_data",
     "get_list_data",
     "get_providers_check_data",

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -652,6 +652,9 @@ def get_providers_models_data(config: ConfigManager, filter_provider: str | None
 
     seen: dict[str, set[str]] = {}
     for cfg in BUILTIN_MODES.values():
+        # P18: alias stubs (`_deprecated_alias_for`) don't carry provider/model.
+        if "_deprecated_alias_for" in cfg:
+            continue
         p = str(cfg["provider"])
         if filter_provider and p != filter_provider:
             continue

--- a/src/thoth/completion/sources.py
+++ b/src/thoth/completion/sources.py
@@ -5,8 +5,7 @@ returns a `list[str]` of candidate completions filtered by `incomplete`
 prefix. The functions are pure (no side effects) so they can also be
 imported by `interactive.py::SlashCommandCompleter` in a future PR.
 
-Per spec §6.4: `mode_kind` is committed as dead code (~5 LOC) for P18
-forward-compat — P18 will wire `--kind` later.
+P18 wired `mode_kind` into `cli_subcommands/modes.py:modes_list` (`--kind`).
 """
 
 from __future__ import annotations

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -433,6 +433,42 @@ class ConfigManager:
                     f"Missing required configuration key: {key}",
                     "Check your configuration file",
                 )
+        self._validate_user_modes_kind()
+
+    def _validate_user_modes_kind(self) -> None:
+        """P18 Phase H: warn-once when a user-defined mode is missing `kind`.
+
+        Builtins are enforced by `tests/test_builtin_modes_have_kind.py`. User
+        modes can omit `kind` for now and fall back to `mode_kind`'s substring
+        heuristic, but we nudge migration. Becomes a hard error in v4.0.0
+        (future P19).
+        """
+        import warnings as _warnings
+
+        user_modes = self.data.get("modes") or {}
+        for name, cfg in user_modes.items():
+            if not isinstance(cfg, dict):
+                continue
+            # Skip alias stubs — they don't carry kind by design
+            if "_deprecated_alias_for" in cfg:
+                continue
+            # Skip user overrides that only override a non-kind field on a builtin —
+            # in that case the merged effective config still has a kind from the builtin
+            if name in BUILTIN_MODES and "kind" in BUILTIN_MODES[name]:
+                # Check whether the user override removed/contradicted kind
+                if "kind" in cfg:
+                    continue
+                # User overlay on top of builtin without overriding kind: silent.
+                continue
+            if "kind" not in cfg:
+                _warnings.warn(
+                    f"User-defined mode '{name}' is missing 'kind' field; falling back "
+                    f"to substring heuristic from model name. Set kind = 'immediate' or "
+                    f"kind = 'background' explicitly. Will become an error in v4.0.0.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            # TODO(v4.0.0): error on missing kind in user modes (future P19)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get configuration value using dot notation"""

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -41,28 +41,32 @@ _config_path: Path | None = None
 BUILTIN_MODES = {
     "default": {
         "provider": "openai",
-        "model": "o3",  # Use standard o3 for default
-        "system_prompt": None,  # No system prompt - pass prompt directly
+        "model": "o3",
+        "kind": "immediate",
+        "system_prompt": None,
         "description": "Default mode - passes prompt directly to LLM without any system prompt",
         "auto_input": False,
     },
     "clarification": {
         "provider": "openai",
-        "model": "o3",  # Use standard o3 for clarification
+        "model": "o3",
+        "kind": "immediate",
         "system_prompt": """I don't want you to follow the above question and instructions; I want you to tell me the ways this is unclear, point out any ambiguities or anything you don't understand. Follow that by asking questions to help clarify the ambiguous points. Once there are no more unclear, ambiguous or not understood portions, help me draft a clear version of the question/instruction.""",
         "description": "Clarifying takes the prompt to get. Ask clarifying questions to get rid of anything that's ambiguous, unclear, and also make suggestions on what would be a better question.",
         "next": "exploration",
     },
-    "mini_research": {  # NEW MODE for quick research
+    "mini_research": {
         "provider": "openai",
         "model": "o4-mini-deep-research",
+        "kind": "background",
         "system_prompt": "Conduct quick, focused research with key findings and essential information. Be concise but thorough.",
         "description": "Fast, lightweight research mode for quick answers using o4-mini-deep-research.",
         "auto_input": False,
     },
     "exploration": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for exploration
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Explore the topic at hand, looking at options, alternatives, different trade-offs, and make recommendations based on the use case or alternative/related technologies.",
         "description": "Exploration looks at the topic at hand and explores some options and alternatives, different trade-offs, and makes recommendations based on the use case or just alternative and related technologies.",
         "previous": "clarification",
@@ -70,7 +74,8 @@ BUILTIN_MODES = {
     },
     "deep_dive": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for deep dive
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Deep dive into the specific technology, giving an overview, going deep on it, discussing it, and exploring it. For APIs, cover what the API is, how it works, assumptions, dependencies, if it's deprecated, common pitfalls. For other technologies, cover what the technology is and how it's used.",
         "description": "This deep dives into a specific technology, giving an overview of it, going deep on it, discussing it, and exploring it.",
         "previous": "exploration",
@@ -78,7 +83,8 @@ BUILTIN_MODES = {
     },
     "tutorial": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for tutorial
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Create a detailed tutorial with examples of how the technologies are used in common scenarios to get started, along with code samples, command-line execution process, and other useful information.",
         "description": "The tutorial goes into a detailed explanation with examples of how the technologies are used in common scenarios to get started.",
         "previous": "deep_dive",
@@ -86,7 +92,8 @@ BUILTIN_MODES = {
     },
     "solution": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for solution
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Design a specific solution to solve the given problem using appropriate technology. Focus on practical implementation.",
         "description": "A solution generally goes into a specific solution to solve a specific problem using technology.",
         "previous": "tutorial",
@@ -94,7 +101,8 @@ BUILTIN_MODES = {
     },
     "prd": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for PRD
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Create a Product Requirements Document based on prior research. Use previous research on solutions and technologies to create a comprehensive requirements document.",
         "description": "Product Requirements Document based on prior research, we'll create the PRD looking at previous research on solutions to technologies.",
         "previous": "solution",
@@ -102,7 +110,8 @@ BUILTIN_MODES = {
     },
     "tdd": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Use deep research for TDD
+        "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Create a Technical Design Document based on the PRD and prior research. Consider best practices on architecture and good abstractions to make things maintainable and well-structured in code.",
         "description": "The Technical Design Document based on the PRD and prior research puts together a technical design document.",
         "previous": "prd",
@@ -110,13 +119,15 @@ BUILTIN_MODES = {
     "thinking": {
         "provider": "openai",
         "model": "o3",
+        "kind": "immediate",
         "temperature": 0.4,
         "system_prompt": "You are a helpful assistant for quick analysis.",
         "description": "Quick thinking and analysis mode for simple questions.",
     },
     "deep_research": {
         "provider": "openai",
-        "model": "o3-deep-research",  # Explicit deep research model
+        "model": "o3-deep-research",
+        "kind": "background",
         "providers": ["openai"],
         "parallel": True,
         "system_prompt": "Conduct comprehensive research with citations and multiple perspectives.\nOrganize findings clearly and highlight key insights.",
@@ -124,9 +135,10 @@ BUILTIN_MODES = {
         "previous": "exploration",
         "auto_input": True,
     },
-    "comparison": {  # Add comparison mode with deep research
+    "comparison": {
         "provider": "openai",
         "model": "o3-deep-research",
+        "kind": "background",
         "system_prompt": "Compare and contrast the given options, technologies, or approaches. Provide a detailed analysis of pros, cons, and recommendations.",
         "description": "Comparative analysis mode for evaluating multiple options.",
     },
@@ -139,20 +151,53 @@ def is_background_model(model: str | None) -> bool:
     Rule: any model name containing the substring "deep-research" is treated
     as background. Case-sensitive by design (OpenAI model IDs are lowercase).
     `None` and empty string return False.
+
+    P18 keeps this helper as the model-level source of truth for "what does
+    *this provider* require for *this model*?" — used inside the OpenAI
+    runtime mismatch check (`OpenAIProvider._validate_kind_for_model`) and
+    inside `progress.py:should_show_spinner`. Resolution-path callers should
+    use `mode_kind(cfg)` instead.
     """
     return "deep-research" in (model or "")
+
+
+def mode_kind(mode_config: dict[str, Any]) -> str:
+    """Canonical resolver for a mode's execution kind.
+
+    Returns "immediate" or "background". Precedence (highest first):
+
+    1. Explicit `kind` field — the canonical declaration.
+    2. Legacy `async: bool` field — emits a one-time DeprecationWarning per
+       process; truthy → background, falsy → immediate. Removed in v4.0.0.
+    3. Substring fallback via `is_background_model(model)` — emits a one-time
+       warning per (mode_id) the first time it's used. User modes missing
+       `kind` hit this path; builtins must declare `kind` explicitly (enforced
+       by `tests/test_builtin_modes_have_kind.py`).
+    """
+    if "kind" in mode_config:
+        return mode_config["kind"]
+    if "async" in mode_config:
+        import warnings
+
+        warnings.warn(
+            "Mode config field 'async' is deprecated; use 'kind' = 'immediate' or "
+            "'background' instead. The 'async' field will be removed in v4.0.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return "background" if mode_config["async"] else "immediate"
+    # Substring fallback — only user modes should reach this path.
+    return "background" if is_background_model(mode_config.get("model")) else "immediate"
 
 
 def is_background_mode(mode_config: dict[str, Any]) -> bool:
     """Return True if a mode submits as a long-running background job.
 
-    Precedence: explicit `async` key wins (truthy → background, falsy →
-    immediate); otherwise delegate to `is_background_model` using the model
-    name.
+    Thin wrapper over `mode_kind(cfg)` kept for backwards-compatibility with
+    code paths that pre-date P18. New code should call `mode_kind(cfg)`
+    directly. Removed in v4.0.0 (see future P19).
     """
-    if "async" in mode_config:
-        return bool(mode_config["async"])
-    return is_background_model(mode_config.get("model"))
+    return mode_kind(mode_config) == "background"
 
 
 class ConfigSchema:

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -55,13 +55,19 @@ BUILTIN_MODES = {
         "description": "Clarifying takes the prompt to get. Ask clarifying questions to get rid of anything that's ambiguous, unclear, and also make suggestions on what would be a better question.",
         "next": "exploration",
     },
-    "mini_research": {
+    "quick_research": {
         "provider": "openai",
         "model": "o4-mini-deep-research",
         "kind": "background",
         "system_prompt": "Conduct quick, focused research with key findings and essential information. Be concise but thorough.",
-        "description": "Fast, lightweight research mode for quick answers using o4-mini-deep-research.",
+        "description": "Lightweight background research with o4-mini-deep-research — faster wall-clock than deep_research, still async.",
         "auto_input": False,
+    },
+    "mini_research": {
+        # P18 rename: `mini_research` → `quick_research`. Stub kept for one
+        # minor with deprecation warning at resolution. Removed in v4.0.0
+        # (future P19).
+        "_deprecated_alias_for": "quick_research",
     },
     "exploration": {
         "provider": "openai",
@@ -442,14 +448,34 @@ class ConfigManager:
         return current
 
     def get_mode_config(self, mode: str) -> dict[str, Any]:
-        """Get mode configuration, merging built-in with user config"""
-        # Start with built-in mode if it exists
-        mode_config = BUILTIN_MODES.get(mode, {}).copy()
+        """Get mode configuration, merging built-in with user config.
 
-        # Override with user config if present
+        P18: resolves `_deprecated_alias_for` stubs with a one-time
+        DeprecationWarning per process. Aliases are removed in v4.0.0.
+        """
+        # Resolve P18 alias stubs (e.g., `mini_research` → `quick_research`).
+        builtin = BUILTIN_MODES.get(mode, {})
+        target_name = builtin.get("_deprecated_alias_for")
+        if target_name:
+            import warnings as _warnings
+
+            _warnings.warn(
+                f"Mode '{mode}' is a deprecated alias for '{target_name}'; "
+                f"update your invocation to use '{target_name}' directly. "
+                f"The alias will be removed in v4.0.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            target_str = str(target_name)
+            mode_config = (BUILTIN_MODES.get(target_str) or {}).copy()
+            # User config overlay still keyed on the original name.
+            user_mode = self.data.get("modes", {}).get(mode, {})
+            mode_config.update(user_mode)
+            return mode_config
+
+        mode_config = builtin.copy()
         user_mode = self.data.get("modes", {}).get(mode, {})
         mode_config.update(user_mode)
-
         return mode_config
 
     def get_effective_config(self) -> dict[str, Any]:

--- a/src/thoth/errors.py
+++ b/src/thoth/errors.py
@@ -122,7 +122,7 @@ class ModeKindMismatchError(ThothError):
                 f"but model '{model}' requires kind='{required_kind}'."
             ),
             (
-                f"Update [modes.{mode_name}] in your config: set "
+                f"Update [modes.{mode_name}] in your config: set "  # nosec B608 — TOML config-edit suggestion, not SQL
                 f"kind = '{required_kind}', or pick a model compatible with "
                 f"'{declared_kind}' execution. Run `thoth modes list` to see "
                 f"current kinds."

--- a/src/thoth/errors.py
+++ b/src/thoth/errors.py
@@ -89,3 +89,43 @@ class APIQuotaError(ThothError):
             "Wait for quota reset or upgrade your plan",
             exit_code=9,
         )
+
+
+class ModeKindMismatchError(ThothError):
+    """A mode's declared `kind` is incompatible with its model's required kind.
+
+    Raised by `OpenAIProvider._validate_kind_for_model` BEFORE any HTTP call,
+    so the user sees a config-edit suggestion instead of a confusing API
+    error mid-run. See spec §5.6 + §4 Q1.
+
+    Attributes (for programmatic access):
+      * mode_name      — the mode whose `kind` is wrong
+      * model          — the model the mode is configured to use
+      * declared_kind  — what the mode says (e.g., "immediate")
+      * required_kind  — what the model actually requires (e.g., "background")
+    """
+
+    def __init__(
+        self,
+        mode_name: str,
+        model: str,
+        declared_kind: str,
+        required_kind: str,
+    ):
+        self.mode_name = mode_name
+        self.model = model
+        self.declared_kind = declared_kind
+        self.required_kind = required_kind
+        super().__init__(
+            (
+                f"Mode '{mode_name}' is declared as kind='{declared_kind}', "
+                f"but model '{model}' requires kind='{required_kind}'."
+            ),
+            (
+                f"Update [modes.{mode_name}] in your config: set "
+                f"kind = '{required_kind}', or pick a model compatible with "
+                f"'{declared_kind}' execution. Run `thoth modes list` to see "
+                f"current kinds."
+            ),
+            exit_code=1,
+        )

--- a/src/thoth/help.py
+++ b/src/thoth/help.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import warnings
 
 import click
@@ -34,6 +35,47 @@ def _dispatch_click_fallback(ctx: click.Context, args: list[str]):
     from thoth.cli import _dispatch_click_fallback as _impl
 
     return _impl(ctx, args, _run_research_default)
+
+
+def _visible_help_context(ctx: click.Context | None) -> click.Context | None:
+    while ctx is not None and getattr(ctx.command, "hidden", False):
+        ctx = ctx.parent
+    return ctx
+
+
+class HelpFirstUsageError(click.UsageError):
+    """Usage error that renders the most specific command help before the error."""
+
+    def __init__(
+        self,
+        original: click.UsageError,
+        *,
+        fallback_ctx: click.Context | None = None,
+    ):
+        self.original = original
+        help_ctx = _visible_help_context(original.ctx) or fallback_ctx
+        super().__init__(original.format_message(), ctx=help_ctx)
+
+    def format_message(self) -> str:
+        return self.original.format_message()
+
+    def show(self, file=None) -> None:
+        if file is None:
+            file = sys.stderr
+        if self.ctx is not None:
+            click.echo(self.ctx.get_help(), file=file)
+            click.echo(file=file)
+        click.echo(f"Error: {self.format_message()}", file=file)
+
+
+def _help_first_usage_error(
+    error: click.UsageError,
+    *,
+    fallback_ctx: click.Context | None = None,
+) -> HelpFirstUsageError:
+    if isinstance(error, HelpFirstUsageError):
+        return error
+    return HelpFirstUsageError(error, fallback_ctx=fallback_ctx)
 
 
 class ThothGroup(click.Group):
@@ -82,7 +124,10 @@ class ThothGroup(click.Group):
             first = args[0]
             # Path 1: registered subcommand → standard dispatch
             if first in self.commands:
-                return super().invoke(ctx)
+                try:
+                    return super().invoke(ctx)
+                except click.UsageError as error:
+                    raise _help_first_usage_error(error, fallback_ctx=ctx) from error
             # Path 2: positional mode dispatch
             if first in BUILTIN_MODES:
                 return _dispatch_click_fallback(ctx, args)

--- a/src/thoth/interactive_picker.py
+++ b/src/thoth/interactive_picker.py
@@ -31,8 +31,12 @@ def immediate_models_for_provider(provider: str, config: ConfigManager) -> list[
     Walks `config.data["modes"]` (merged BUILTIN + user overlay), so user-defined
     modes in `[modes.*]` are surfaced. No provider-specific hardcoded extras —
     the picker reflects what is actually configured.
+
+    P18: each mode dict carries `kind`; we filter on declared kind first
+    (canonical), falling back to substring sniff via `mode_kind` for legacy
+    user modes that haven't migrated.
     """
-    from thoth.config import is_background_model
+    from thoth.config import mode_kind
 
     seen: set[str] = set()
     for cfg in config.data.get("modes", {}).values():
@@ -41,6 +45,6 @@ def immediate_models_for_provider(provider: str, config: ConfigManager) -> list[
         if cfg.get("provider") != provider:
             continue
         model = cfg.get("model")
-        if isinstance(model, str) and not is_background_model(model):
+        if isinstance(model, str) and mode_kind(cfg) == "immediate":
             seen.add(model)
     return sorted(seen)

--- a/src/thoth/models.py
+++ b/src/thoth/models.py
@@ -5,6 +5,7 @@
 - InteractiveInitialSettings: CLI-arg → interactive-mode defaults bundle
 - ModelCache: per-provider disk cache for model-list responses
 - VALID_OPERATION_STATES / VALID_STATE_TRANSITIONS: state-machine constants
+- ModelSpec / KNOWN_MODELS: P18 registry derived from BUILTIN_MODES
 """
 
 from __future__ import annotations
@@ -14,9 +15,75 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, NamedTuple, cast
 
 from thoth.paths import user_model_cache_dir
+
+
+class ModelSpec(NamedTuple):
+    """A (provider, model, kind) triple. The canonical "this model exists" record.
+
+    Built once at import time by `derive_known_models()` from `BUILTIN_MODES`.
+    Models referenced only by user-defined modes are not in `KNOWN_MODELS` —
+    user opted in, user owns kind correctness.
+    """
+
+    id: str
+    provider: str
+    kind: Literal["immediate", "background"]
+
+
+def derive_known_models(builtin_modes: dict[str, dict[str, Any]] | None = None) -> list[ModelSpec]:
+    """Build the canonical model registry from `BUILTIN_MODES`.
+
+    Every `(provider, model)` pair referenced by any non-alias builtin is a
+    "known" model. Cross-mode kind conflicts (same `(provider, model)` declared
+    with two different kinds across builtins) raise `ThothError` — that
+    indicates a thoth bug, not a user-config issue.
+
+    Alias stubs (entries carrying `_deprecated_alias_for`) are skipped because
+    they delegate to a real mode and don't carry provider/model/kind themselves.
+
+    Pass `builtin_modes` to test against a synthetic catalog; production code
+    calls with no argument to read the real `BUILTIN_MODES`.
+    """
+    # Lazy import to dodge the config.py ↔ models.py circular at module load.
+    from thoth.config import BUILTIN_MODES
+    from thoth.errors import ThothError
+
+    modes = builtin_modes if builtin_modes is not None else BUILTIN_MODES
+    seen: dict[tuple[str, str], ModelSpec] = {}
+    for mode_name, cfg in modes.items():
+        if "_deprecated_alias_for" in cfg:
+            continue
+        provider_raw = cfg.get("provider")
+        model_raw = cfg.get("model")
+        kind_raw = cfg.get("kind")
+        if (
+            not isinstance(provider_raw, str)
+            or not isinstance(model_raw, str)
+            or kind_raw not in ("immediate", "background")
+        ):
+            raise ThothError(
+                f"Builtin mode '{mode_name}' is missing one of provider/model/kind, "
+                f"or kind is not 'immediate'/'background'",
+                "This is a thoth bug — every non-alias builtin must declare all three fields.",
+            )
+        provider: str = provider_raw
+        model: str = model_raw
+        # ty cannot narrow `dict.get` returns through tuple-membership; the
+        # `not in (...)` guard above already excludes everything else.
+        kind = cast(Literal["immediate", "background"], kind_raw)
+        key = (provider, model)
+        if key in seen and seen[key].kind != kind:
+            raise ThothError(
+                f"Inconsistent kind for {provider}/{model}: "
+                f"declared as both '{seen[key].kind}' and '{kind}' across builtin modes "
+                f"(latest conflict at mode '{mode_name}')",
+                "Pick one kind for this (provider, model) pair and update the conflicting builtin.",
+            )
+        seen[key] = ModelSpec(id=model, provider=provider, kind=kind)
+    return list(seen.values())
 
 
 class InputMode(Enum):
@@ -196,3 +263,10 @@ class ModelCache:
             return datetime.now() - cached_at
         except (json.JSONDecodeError, ValueError, KeyError):
             return None
+
+
+# Module-level registry — built once at import. Sits at the end of the module
+# so `derive_known_models()` is fully defined before it runs. The function does
+# its own lazy import of `BUILTIN_MODES` so this top-level call is safe even if
+# models.py is imported before config.py finishes initializing in some path.
+KNOWN_MODELS: list[ModelSpec] = derive_known_models()

--- a/src/thoth/modes_cmd.py
+++ b/src/thoth/modes_cmd.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from thoth._secrets import _mask_tree
-from thoth.config import BUILTIN_MODES, ConfigManager, is_background_mode
+from thoth.config import BUILTIN_MODES, ConfigManager, mode_kind
 
 Source = Literal["builtin", "user", "overridden"]
 Kind = Literal["immediate", "background", "unknown"]
@@ -45,10 +45,26 @@ def _normalize_providers(cfg: dict[str, Any]) -> list[str]:
 
 
 def _derive_kind(cfg: dict[str, Any], warnings: list[str]) -> Kind:
-    if not cfg.get("model") and "async" not in cfg:
-        warnings.append("missing `model` and no explicit `async` — kind unknown")
+    """Resolve a mode's display kind for the `thoth modes` table.
+
+    P18: prefer the declared `kind` field; fall back to `mode_kind` (which
+    handles the legacy `async` key + substring sniff). Missing model AND no
+    declared kind AND no async → kind=unknown with a warning.
+    """
+    if "kind" in cfg:
+        kind_raw = cfg["kind"]
+        if kind_raw == "immediate":
+            return "immediate"
+        if kind_raw == "background":
+            return "background"
+        warnings.append(f"invalid `kind` value {kind_raw!r} — must be 'immediate' or 'background'")
         return "unknown"
-    return "background" if is_background_mode(cfg) else "immediate"
+    if not cfg.get("model") and "async" not in cfg:
+        warnings.append("missing `model` and no explicit `kind`/`async` — kind unknown")
+        return "unknown"
+    # Legacy fallback path; mode_kind() emits its own DeprecationWarning if `async` is set.
+    resolved = mode_kind(cfg)
+    return "background" if resolved == "background" else "immediate"
 
 
 def _compute_overrides(builtin: dict[str, Any], user: dict[str, Any]) -> dict[str, dict[str, Any]]:

--- a/src/thoth/modes_cmd.py
+++ b/src/thoth/modes_cmd.py
@@ -176,15 +176,19 @@ def _info_to_dict(m: ModeInfo, show_secrets: bool) -> dict[str, Any]:
     return d
 
 
+_VALID_KINDS = ("immediate", "background")
+
+
 def _parse_list_flags(
     args: list[str],
-) -> tuple[bool, bool, str, str | None, bool, int]:
-    """Return (as_json, show_secrets, source, name, full, error_rc). rc=0 means ok."""
+) -> tuple[bool, bool, str, str | None, bool, str | None, int]:
+    """Return (as_json, show_secrets, source, name, full, kind, error_rc). rc=0 means ok."""
     as_json = False
     show_secrets = False
     source = "all"
     name: str | None = None
     full = False
+    kind: str | None = None
     i = 0
     while i < len(args):
         a = args[i]
@@ -200,24 +204,35 @@ def _parse_list_flags(
         elif a == "--source":
             if i + 1 >= len(args):
                 _get_console().print("[red]Error:[/red] --source requires a value")
-                return as_json, show_secrets, source, name, full, 2
+                return as_json, show_secrets, source, name, full, kind, 2
             source = args[i + 1]
             if source not in _VALID_SOURCES:
                 _get_console().print(
                     f"[red]Error:[/red] --source must be one of {', '.join(_VALID_SOURCES)}"
                 )
-                return as_json, show_secrets, source, name, full, 2
+                return as_json, show_secrets, source, name, full, kind, 2
             i += 2
         elif a == "--name":
             if i + 1 >= len(args):
                 _get_console().print("[red]Error:[/red] --name requires a value")
-                return as_json, show_secrets, source, name, full, 2
+                return as_json, show_secrets, source, name, full, kind, 2
             name = args[i + 1]
+            i += 2
+        elif a == "--kind":
+            if i + 1 >= len(args):
+                _get_console().print("[red]Error:[/red] --kind requires a value")
+                return as_json, show_secrets, source, name, full, kind, 2
+            kind = args[i + 1]
+            if kind not in _VALID_KINDS:
+                _get_console().print(
+                    f"[red]Error:[/red] --kind must be one of {', '.join(_VALID_KINDS)}"
+                )
+                return as_json, show_secrets, source, name, full, kind, 2
             i += 2
         else:
             _get_console().print(f"[red]Error:[/red] unknown arg: {a}")
-            return as_json, show_secrets, source, name, full, 2
-    return as_json, show_secrets, source, name, full, 0
+            return as_json, show_secrets, source, name, full, kind, 2
+    return as_json, show_secrets, source, name, full, kind, 0
 
 
 def _render_detail(m: ModeInfo, full: bool, show_secrets: bool) -> None:
@@ -254,12 +269,16 @@ def get_modes_list_data(
     source: str,
     show_secrets: bool,
     config_path: str | None = None,
+    kind: str | None = None,
 ) -> dict:
     """Pure data function for `thoth modes list`.
 
     Returns:
         - {"modes": [...]} when `name` is None
         - {"mode": {...} | None} when `name` is set
+
+    P18 Phase D: optional `kind` filter (`"immediate"` | `"background"`).
+
     Per spec §7.2, this function NEVER takes an `as_json` flag — the
     JSON-vs-Rich choice lives at the subcommand-wrapper layer.
     """
@@ -269,6 +288,8 @@ def get_modes_list_data(
 
     if source != "all":
         infos = [m for m in infos if m.source == source]
+    if kind is not None:
+        infos = [m for m in infos if m.kind == kind]
 
     if name is not None:
         match = next((m for m in infos if m.name == name), None)
@@ -282,7 +303,7 @@ def get_modes_list_data(
 
 
 def _op_list(args: list[str], *, config_path: str | None = None) -> int:
-    as_json, show_secrets, source, name, full, rc = _parse_list_flags(args)
+    as_json, show_secrets, source, name, full, kind, rc = _parse_list_flags(args)
     if rc != 0:
         return rc
 
@@ -292,9 +313,11 @@ def _op_list(args: list[str], *, config_path: str | None = None) -> int:
 
     # Q5-A row 11.i: source filter is applied BEFORE the --name short-circuit
     # so `--name X --source Y` is a true intersection (empty result if X is
-    # not in source Y).
+    # not in source Y). The same applies to --kind (P18 Phase D).
     if source != "all":
         infos = [m for m in infos if m.source == source]
+    if kind is not None:
+        infos = [m for m in infos if m.kind == kind]
 
     if name is not None:
         match = next((m for m in infos if m.name == name), None)

--- a/src/thoth/progress.py
+++ b/src/thoth/progress.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any
 
-from thoth.config import is_background_model
+from thoth.config import is_background_model, mode_kind
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -19,18 +19,30 @@ def should_show_spinner(
     async_mode: bool,
     verbose: bool,
     stream: IO[str] | None = None,
+    mode_cfg: dict[str, Any] | None = None,
 ) -> bool:
     """Decide whether to engage the progress spinner.
 
     Engages only when ALL hold:
-      - the resolved model is a background (deep-research) model
+      - the resolved mode is `kind = "background"` (P18) — falls back to the
+        model-substring check `is_background_model(model)` for legacy callers
+        that don't pass `mode_cfg`
       - --async is NOT set (sync caller is the one waiting)
       - --verbose is NOT set (verbose keeps raw-log UX)
       - the output stream is a TTY (avoid clobbering pipes/CI)
+
+    P18 contract: when `mode_cfg` is supplied, declared `kind` is the source
+    of truth — an immediate-kind mode NEVER shows a spinner, even if its model
+    name happens to match the deep-research substring (e.g., user mode forcing
+    `kind="immediate"` on a deep-research model would already have failed
+    `_validate_kind_for_model` upstream, but we defend in depth).
     """
     if async_mode or verbose:
         return False
-    if not is_background_model(model):
+    if mode_cfg is not None:
+        if mode_kind(mode_cfg) != "background":
+            return False
+    elif not is_background_model(model):
         return False
     s = stream if stream is not None else sys.stdout
     return bool(getattr(s, "isatty", lambda: False)())

--- a/src/thoth/providers/__init__.py
+++ b/src/thoth/providers/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any
 
-from thoth.config import is_background_mode
+from thoth.config import mode_kind
 from thoth.errors import APIKeyError, ThothError
 from thoth.providers.base import ResearchProvider
 from thoth.providers.mock import MockProvider
@@ -107,8 +107,15 @@ def create_provider(
     if mode_config and "model" in mode_config and provider_name == "openai":
         provider_config["model"] = mode_config["model"]
 
-    # Apply background mode for deep research models
-    if provider_name == "openai" and is_background_mode(provider_config):
+    # Thread the mode's declared `kind` into provider_config so the OpenAI
+    # provider's runtime validator (`_validate_kind_for_model`) can detect
+    # mismatches before any HTTP call. P18.
+    if mode_config and "kind" in mode_config:
+        provider_config["kind"] = mode_config["kind"]
+
+    # Apply background mode for deep research models. P18: resolution path
+    # uses `mode_kind` (declared `kind` first; substring fallback for legacy).
+    if provider_name == "openai" and mode_kind(provider_config) == "background":
         provider_config["background"] = True
 
     cls = PROVIDERS[provider_name]

--- a/src/thoth/providers/base.py
+++ b/src/thoth/providers/base.py
@@ -1,12 +1,42 @@
 """Base class for research providers.
 
 ResearchProvider defines the contract every provider implements:
-submit → check_status → get_result, plus optional list_models / reconnect.
+submit → check_status → get_result, plus optional list_models / reconnect /
+stream / cancel.
+
+P18 added:
+- `stream(prompt, mode, ...) -> AsyncIterator[StreamEvent]`: live token
+  delivery for immediate-kind runs. Default raises NotImplementedError;
+  subclasses opt in. The immediate execution path will fall back to
+  submit + get_result if a provider doesn't implement stream.
+- `cancel(job_id)`: best-effort upstream cancel for in-flight background
+  jobs. Default raises NotImplementedError; the `thoth cancel` CLI catches
+  and reports "upstream cancel not supported".
 """
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass
+class StreamEvent:
+    """One chunk emitted by `provider.stream()`.
+
+    `kind` distinguishes text deltas from sidechannel events:
+      * "text"      — main content delta; the typical case
+      * "reasoning" — model reasoning summary chunk (optional, future)
+      * "citation"  — annotation/citation metadata (optional, future)
+      * "done"      — terminal marker; no more events follow
+
+    Callers should treat unknown kinds as future-proof: skip what they
+    don't recognize; don't error.
+    """
+
+    kind: Literal["text", "reasoning", "citation", "done"]
+    text: str
 
 
 class ResearchProvider:
@@ -71,3 +101,35 @@ class ResearchProvider:
         job state from a persisted job identifier.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support resume/reconnect")
+
+    async def stream(
+        self,
+        prompt: str,
+        mode: str,
+        system_prompt: str | None = None,
+        verbose: bool = False,
+    ) -> AsyncIterator[StreamEvent]:
+        """Yield content chunks for immediate-mode use.
+
+        P18: subclasses opt in by implementing this; the default raises
+        NotImplementedError so the immediate-execution path can fall back
+        to submit + get_result for providers that don't support streaming.
+
+        Should yield a terminal `StreamEvent(kind="done", text="")` so
+        callers can detect end-of-stream without relying on iterator
+        exhaustion.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support streaming")
+        # Unreachable; pleases the static checkers expecting an async generator.
+        if False:  # pragma: no cover
+            yield StreamEvent(kind="done", text="")
+
+    async def cancel(self, job_id: str) -> dict[str, Any]:
+        """Best-effort cancel of an in-flight job. Returns final status dict.
+
+        P18: subclasses with upstream cancel support override; otherwise the
+        default raises NotImplementedError. The `thoth cancel` CLI catches
+        and reports "upstream cancel not supported, local checkpoint marked
+        cancelled" so the operation is at least locally cancelled.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support cancel")

--- a/src/thoth/providers/mock.py
+++ b/src/thoth/providers/mock.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import AsyncIterator
 from typing import Any
 
-from thoth.providers.base import ResearchProvider
+from thoth.providers.base import ResearchProvider, StreamEvent
 from thoth.utils import generate_operation_id
 
 
@@ -126,3 +127,34 @@ This mock provider successfully completed the research task.
             {"id": "mock-model-v1", "created": 1680000000, "owned_by": "mock"},
             {"id": "mock-model-v2", "created": 1690000000, "owned_by": "mock"},
         ]
+
+    async def stream(
+        self,
+        prompt: str,
+        mode: str,
+        system_prompt: str | None = None,
+        verbose: bool = False,
+    ) -> AsyncIterator[StreamEvent]:
+        """Yield deterministic chunks for hermetic test coverage of streaming.
+
+        The chunked output is structured so callers can verify:
+          * the prompt round-trips into the streamed text
+          * the final event is `done`
+        """
+        chunks = [
+            f"# Mock streaming response (mode={mode})\n\n",
+            "Echo: ",
+            prompt,
+            "\n\nDone.",
+        ]
+        for c in chunks:
+            yield StreamEvent(kind="text", text=c)
+            # Yield to the event loop between chunks so async consumers can
+            # interleave; tests that don't await scheduling still pass.
+            await asyncio.sleep(0)
+        yield StreamEvent(kind="done", text="")
+
+    async def cancel(self, job_id: str) -> dict[str, Any]:
+        """Pop the job and report cancelled. Used by extended cancel tests."""
+        self.jobs.pop(job_id, None)
+        return {"status": "cancelled", "error": "cancelled by user"}

--- a/src/thoth/providers/mock.py
+++ b/src/thoth/providers/mock.py
@@ -137,10 +137,20 @@ This mock provider successfully completed the research task.
     ) -> AsyncIterator[StreamEvent]:
         """Yield deterministic chunks for hermetic test coverage of streaming.
 
-        The chunked output is structured so callers can verify:
+        Honors THOTH_MOCK_BEHAVIOR for parity with the polling-loop path:
+        `permanent` and `flake:N` raise so the immediate path's failure
+        handling matches what background-mode tests expect.
+
+        The happy-path chunked output is structured so callers can verify:
           * the prompt round-trips into the streamed text
           * the final event is `done`
         """
+        if self._behavior == "permanent":
+            raise RuntimeError("Mock permanent failure")
+        if self._behavior.startswith("flake:"):
+            # Stream path doesn't model retry; permanent-fail when flake is set.
+            raise RuntimeError(f"Mock streaming failure (behavior={self._behavior})")
+
         chunks = [
             f"# Mock streaming response (mode={mode})\n\n",
             "Echo: ",

--- a/src/thoth/providers/openai.py
+++ b/src/thoth/providers/openai.py
@@ -346,6 +346,44 @@ class OpenAIProvider(ResearchProvider):
             "created_at": datetime.now(),
         }
 
+    async def cancel(self, job_id: str) -> dict[str, Any]:
+        """Best-effort upstream cancel via OpenAI Responses API.
+
+        P18 Phase G. Documented in `planning/p18-cancel-research.md`:
+          * `client.responses.cancel(job_id)` works for queued/in_progress
+            background responses.
+          * Already-completed jobs return status='completed' (no error).
+          * The full Response object is returned; we map .status to our
+            uniform status dict.
+
+        If `job_id` isn't in our local `self.jobs` dict (e.g., `thoth cancel`
+        invoked after a fresh process start), we attempt `reconnect()` first.
+        """
+        if job_id not in self.jobs:
+            try:
+                await self.reconnect(job_id)
+            except Exception as e:
+                return {
+                    "status": "permanent_error",
+                    "error": f"reconnect failed: {e}",
+                    "error_class": type(e).__name__,
+                }
+        try:
+            response = await self.client.responses.cancel(job_id)
+            status = getattr(response, "status", None)
+            if status == "completed":
+                # Job finished before cancel landed.
+                return {"status": "completed", "progress": 1.0}
+            # Treat any non-completed terminal state as cancelled (cancelled,
+            # failed, incomplete, or any future state).
+            return {"status": "cancelled", "error": "Response was cancelled"}
+        except Exception as e:
+            return {
+                "status": "permanent_error",
+                "error": str(e),
+                "error_class": type(e).__name__,
+            }
+
     async def stream(
         self,
         prompt: str,

--- a/src/thoth/providers/openai.py
+++ b/src/thoth/providers/openai.py
@@ -260,6 +260,12 @@ class OpenAIProvider(ResearchProvider):
         job_info = self.jobs[job_id]
 
         # If not background mode, it's already completed
+        # TODO(v4.0.0 / future P19): remove this shortcut. Post-P18,
+        # immediate-kind runs use `_execute_immediate` which calls
+        # `provider.stream()` directly and never reaches `check_status`.
+        # The shortcut survives only as defense-in-depth for edge cases like
+        # `--async` on a non-deep-research model. Confirm dead via a full
+        # audit before deletion.
         if not job_info.get("background", False):
             return {"status": "completed", "progress": 1.0}
 

--- a/src/thoth/providers/openai.py
+++ b/src/thoth/providers/openai.py
@@ -19,7 +19,13 @@ from tenacity import (
 )
 
 from thoth.config import is_background_model
-from thoth.errors import APIKeyError, APIQuotaError, ProviderError, ThothError
+from thoth.errors import (
+    APIKeyError,
+    APIQuotaError,
+    ModeKindMismatchError,
+    ProviderError,
+    ThothError,
+)
 from thoth.models import ModelCache
 from thoth.providers.base import ResearchProvider
 
@@ -135,6 +141,28 @@ class OpenAIProvider(ResearchProvider):
         timeout = self.config.get("timeout", 30.0)
         self.client = AsyncOpenAI(api_key=api_key, timeout=httpx.Timeout(timeout, connect=5.0))
 
+    def _validate_kind_for_model(self, mode: str) -> None:
+        """Refuse to submit when declared `kind` contradicts the model's required kind.
+
+        P18 contract: a mode declared `kind = "immediate"` cannot use a
+        deep-research model — those models require OpenAI's background flow.
+        Raised BEFORE any HTTP call so users see a config-edit suggestion
+        instead of a confusing API error mid-run. The reverse case
+        (`background` declared, regular model) is legal — OpenAI lets you
+        force-background any model — and is not checked.
+
+        See `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md`
+        §5.6 + §4 Q1.
+        """
+        declared = self.config.get("kind")
+        if declared == "immediate" and is_background_model(self.model):
+            raise ModeKindMismatchError(
+                mode_name=mode,
+                model=self.model,
+                declared_kind="immediate",
+                required_kind="background",
+            )
+
     async def submit(
         self, prompt: str, mode: str, system_prompt: str | None = None, verbose: bool = False
     ) -> str:
@@ -143,8 +171,11 @@ class OpenAIProvider(ResearchProvider):
         Raw openai.* exceptions from the retryable inner call are mapped here to
         ThothError subclasses so callers always see a single error taxonomy.
         """
+        self._validate_kind_for_model(mode)
         try:
             return await self._submit_with_retry(prompt, mode, system_prompt, verbose)
+        except ModeKindMismatchError:
+            raise
         except (openai.APIError, Exception) as e:
             raise _map_openai_error(e, model=self.model, verbose=verbose) from e
 

--- a/src/thoth/providers/openai.py
+++ b/src/thoth/providers/openai.py
@@ -346,6 +346,65 @@ class OpenAIProvider(ResearchProvider):
             "created_at": datetime.now(),
         }
 
+    async def stream(
+        self,
+        prompt: str,
+        mode: str,
+        system_prompt: str | None = None,
+        verbose: bool = False,
+    ):
+        """Yield text deltas from the OpenAI Responses streaming API.
+
+        P18 Phase E: only legal for non-background (immediate-kind) models.
+        Background models require server-side async submission and don't
+        stream tokens. The `_validate_kind_for_model` runtime check upstream
+        catches the mismatch; this method is defense-in-depth.
+
+        Translates OpenAI's `response.output_text.delta` events into our
+        `StreamEvent(kind="text", text=delta)` and emits a terminal
+        `StreamEvent(kind="done", text="")` when the stream completes.
+        """
+        from thoth.providers.base import StreamEvent
+
+        self._validate_kind_for_model(mode)
+        if is_background_model(self.model):
+            raise NotImplementedError(
+                f"OpenAIProvider.stream(): model {self.model!r} requires background "
+                f"submission; streaming is not supported. Use submit() + check_status() instead."
+            )
+
+        input_messages: list[dict[str, Any]] = []
+        if system_prompt:
+            input_messages.append(
+                {
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": system_prompt}],
+                }
+            )
+        input_messages.append({"role": "user", "content": [{"type": "input_text", "text": prompt}]})
+
+        request_params: dict[str, Any] = {
+            "model": self.model,
+            "input": input_messages,
+        }
+        # o-series response models reject `temperature`; only set it on chat-style models
+        if not self.model.startswith("o"):
+            request_params["temperature"] = self.config.get("temperature", 0.7)
+
+        try:
+            async with self.client.responses.stream(**request_params) as stream:
+                async for event in stream:
+                    event_type = getattr(event, "type", None)
+                    if event_type == "response.output_text.delta":
+                        delta = getattr(event, "delta", "") or ""
+                        if delta:
+                            yield StreamEvent(kind="text", text=delta)
+                    # Other event types (response.created, response.completed, etc.)
+                    # are skipped — we only surface text deltas to consumers for now.
+            yield StreamEvent(kind="done", text="")
+        except (openai.APIError, Exception) as e:
+            raise _map_openai_error(e, model=self.model, verbose=verbose) from e
+
     async def get_result(self, job_id: str, verbose: bool = False) -> str:
         """Get the Deep Research result"""
         if job_id not in self.jobs:

--- a/src/thoth/run.py
+++ b/src/thoth/run.py
@@ -185,6 +185,8 @@ async def run_research(
     timeout_override: float | None = None,
     ctx: AppContext | None = None,
     model_override: str | None = None,
+    out_specs: tuple[str, ...] = (),
+    append: bool = False,
 ):
     """Execute research operation.
 
@@ -347,23 +349,53 @@ async def run_research(
             print_saved_not_submitted(operation_id)
             raise click.Abort()
 
+    # P18 Phase E: dispatch on mode_kind. Immediate-kind runs route to
+    # `_execute_immediate` which streams via `provider.stream()` to a
+    # MultiSink (stdout / file / tee) and falls back to submit + get_result
+    # if the provider doesn't implement streaming. Background runs continue
+    # through the existing polling-loop path. The `--out`/`--append` flags
+    # are honored only on the immediate path; background runs ignore them
+    # (deferred per spec §3 / §10).
+    from thoth.config import mode_kind as _mode_kind_local
+
+    is_immediate = _mode_kind_local(mode_config) == "immediate"
+
     try:
-        await _execute_research(
-            operation,
-            checkpoint_manager,
-            output_manager,
-            config,
-            mode_config,
-            providers,
-            quiet,
-            verbose,
-            output_dir,
-            combined,
-            project,
-            mode,
-            prompt,
-            ctx=ctx,
-        )
+        if is_immediate and not async_mode:
+            await _execute_immediate(
+                operation,
+                checkpoint_manager,
+                output_manager,
+                config,
+                mode_config,
+                providers,
+                quiet,
+                verbose,
+                output_dir,
+                project,
+                mode,
+                prompt,
+                out_specs,
+                append,
+                ctx=ctx,
+            )
+        else:
+            await _execute_research(
+                operation,
+                checkpoint_manager,
+                output_manager,
+                config,
+                mode_config,
+                providers,
+                quiet,
+                verbose,
+                output_dir,
+                combined,
+                project,
+                mode,
+                prompt,
+                ctx=ctx,
+            )
     except (click.Abort, KeyboardInterrupt):
         if operation.status not in ("cancelled", "failed", "completed"):
             operation.transition_to("cancelled")
@@ -376,6 +408,110 @@ async def run_research(
 
     if operation.status == "failed":
         raise click.Abort()
+
+
+async def _execute_immediate(
+    operation: OperationStatus,
+    checkpoint_manager: CheckpointManager,
+    output_manager: OutputManager,
+    config: ConfigManager,
+    mode_config: dict,
+    providers: dict,
+    quiet: bool,
+    verbose: bool,
+    output_dir: str | None,
+    project: str | None,
+    mode: str,
+    prompt: str,
+    out_specs: tuple[str, ...],
+    append: bool,
+    ctx: AppContext | None = None,
+) -> None:
+    """P18 Phase E: streaming execution path for immediate-kind runs.
+
+    Uses `provider.stream()` to deliver tokens to a `MultiSink` (stdout /
+    file / tee). Falls back to `submit() + get_result()` for providers that
+    don't implement streaming yet (e.g., Mock pre-Phase E, or future
+    providers). Saves the aggregated result via `output_manager.save_result`
+    only if `--project` is set (matching pre-P18 background behavior of
+    only writing checkpoints when persistence is requested).
+
+    Skips the polling loop entirely — single provider, single stream call,
+    no Progress bar, no operation-ID echo, no resume hint.
+    """
+    if ctx is None:
+        ctx = AppContext(config=config, verbose=verbose)
+    target_console = ctx.console  # noqa: F811
+
+    from thoth.sinks import MultiSink
+
+    # Single-provider immediate runs are the norm. Pick the first one.
+    provider_name, provider_instance = next(iter(providers.items()))
+    operation.providers[provider_name] = {"status": "running", "job_id": "<streaming>"}
+    operation.transition_to("running")
+    # Always save checkpoint — `thoth list` / `thoth status` / `thoth resume`
+    # need it, and the global checkpoint dir lives outside the project dir
+    # anyway. `--project` only governs whether we ALSO save the result file.
+    await checkpoint_manager.save(operation)
+
+    system_prompt = mode_config.get("system_prompt") or ""
+    aggregated: list[str] = []
+
+    sink = MultiSink.from_specs(list(out_specs), append=append)
+    try:
+        try:
+            try:
+                async for event in provider_instance.stream(
+                    prompt, mode, system_prompt, verbose=verbose
+                ):
+                    if event.kind == "text":
+                        sink.write(event.text)
+                        aggregated.append(event.text)
+                    elif event.kind == "done":
+                        break
+            except NotImplementedError:
+                # Fallback for providers that haven't implemented stream yet.
+                job_id = await provider_instance.submit(
+                    prompt, mode, system_prompt, verbose=verbose
+                )
+                operation.providers[provider_name]["job_id"] = job_id
+                content = await provider_instance.get_result(job_id, verbose=verbose)
+                sink.write(content)
+                aggregated.append(content)
+        except Exception as e:
+            # Streaming runs treat any exception as a permanent failure —
+            # immediate-kind ops have no upstream job to retry/resume against.
+            operation.transition_to("failed", error=str(e))
+            operation.failure_type = "permanent"
+            await checkpoint_manager.save(operation)
+            raise
+    finally:
+        sink.close()
+
+    final_text = "".join(aggregated)
+    operation.providers[provider_name]["status"] = "completed"
+
+    # Persist via output_manager only when the user asked for it via
+    # --project. Otherwise the streamed output is the user-visible result.
+    if project:
+        provider_model = getattr(provider_instance, "model", None)
+        output_path = await output_manager.save_result(
+            operation,
+            provider_name,
+            final_text,
+            output_dir,
+            model=provider_model,
+            system_prompt=system_prompt,
+        )
+        operation.output_paths[provider_name] = output_path
+
+    operation.transition_to("completed")
+    await checkpoint_manager.save(operation)
+
+    if not quiet and project:
+        target_console.print(
+            f"\n[green]✓[/green] Saved to: [dim]{output_dir or 'current directory'}/{project}/[/dim]"
+        )
 
 
 async def _run_polling_loop(

--- a/src/thoth/run.py
+++ b/src/thoth/run.py
@@ -243,6 +243,7 @@ async def run_research(
         created_at=datetime.now(),
         updated_at=datetime.now(),
         project=project,
+        input_files=input_files,
     )
 
     checkpoint_manager = CheckpointManager(config)
@@ -402,8 +403,9 @@ async def run_research(
             await checkpoint_manager.save(operation)
         raise
     except Exception as e:
-        operation.transition_to("failed", error=str(e))
-        await checkpoint_manager.save(operation)
+        if operation.status not in ("cancelled", "failed", "completed"):
+            operation.transition_to("failed", error=str(e))
+            await checkpoint_manager.save(operation)
         raise
 
     if operation.status == "failed":
@@ -481,10 +483,16 @@ async def _execute_immediate(
         except Exception as e:
             # Streaming runs treat any exception as a permanent failure —
             # immediate-kind ops have no upstream job to retry/resume against.
+            target_console.print(
+                f"\n[red]✗[/red] {provider_name.title()} permanent failure: {str(e)}"
+            )
+            operation.providers[provider_name]["status"] = "failed"
+            operation.providers[provider_name]["failure_type"] = "permanent"
+            operation.providers[provider_name]["error"] = str(e)
             operation.transition_to("failed", error=str(e))
             operation.failure_type = "permanent"
             await checkpoint_manager.save(operation)
-            raise
+            return
     finally:
         sink.close()
 

--- a/src/thoth/run.py
+++ b/src/thoth/run.py
@@ -63,17 +63,34 @@ def _poll_display(
     label: str = "Deep research running",
     expected_minutes: int = 20,
     rich_console: Console | None = None,
+    mode_cfg: dict[str, Any] | None = None,
 ):
-    """Yield ONE polling-display context: Progress XOR spinner, never both.
+    """Yield ONE polling-display context: Progress XOR spinner XOR none.
 
-    When ``should_show_spinner`` engages (background model, sync, TTY,
-    non-verbose, non-quiet), the spinner runs alone. Otherwise the existing
-    ``rich.Progress`` runs as before. The caller submits jobs and tracks
-    task ids before entering this context, so the polling loop only deals
-    with whichever display is yielded (or ``None`` for the spinner case).
+    P18: when ``mode_cfg`` declares ``kind = "immediate"``, NEITHER the
+    spinner NOR the Progress bar engages — immediate runs complete in one
+    polling tick and any progress UI is theatre. Yield ``None`` for that
+    case; the polling loop's existing per-tick render code handles ``None``
+    by simply not rendering.
+
+    When ``should_show_spinner`` engages (background mode, sync, TTY,
+    non-verbose, non-quiet), the spinner runs alone. Otherwise (background
+    mode in non-TTY, verbose, or quiet) the legacy ``rich.Progress`` bar
+    runs as before.
     """
     target_console = rich_console if rich_console is not None else console
-    if not quiet and should_show_spinner(model=mode_model, async_mode=False, verbose=verbose):
+    if mode_cfg is not None:
+        from thoth.config import mode_kind as _mode_kind
+
+        if _mode_kind(mode_cfg) != "background":
+            # Immediate runs: yield no display. The polling loop tolerates
+            # `progress=None`; immediate runs only spin the loop once because
+            # OpenAIProvider.check_status short-circuits non-background jobs.
+            yield None
+            return
+    if not quiet and should_show_spinner(
+        model=mode_model, async_mode=False, verbose=verbose, mode_cfg=mode_cfg
+    ):
         with run_with_spinner(label, expected_minutes=expected_minutes, console=target_console):
             yield None
     else:
@@ -599,8 +616,19 @@ async def _execute_research(
     await checkpoint_manager.save(operation)
 
     mode_model = mode_config.get("model")
+    # P18: gate the resume-hint emission on mode_kind. Immediate-kind runs
+    # have no upstream job to reattach to, so a "thoth resume {id}" hint is a
+    # dead end. Computed once here, used at the four failure-emission sites
+    # below.
+    from thoth.config import mode_kind as _mode_kind
+
+    is_background_kind = _mode_kind(mode_config) == "background"
     with _poll_display(
-        quiet=quiet, mode_model=mode_model, verbose=verbose, rich_console=console
+        quiet=quiet,
+        mode_model=mode_model,
+        verbose=verbose,
+        rich_console=console,
+        mode_cfg=mode_config,
     ) as progress:
         if progress is not None:
             for provider_name, info in jobs.items():
@@ -623,7 +651,7 @@ async def _execute_research(
         )
 
     if operation.status == "failed":
-        if operation.failure_type == "recoverable":
+        if operation.failure_type == "recoverable" and is_background_kind:
             console.print(
                 f"\n[cyan]This failure is recoverable.[/cyan] "
                 f"Resume with: [bold]thoth resume {operation.id}[/bold]"
@@ -648,7 +676,7 @@ async def _execute_research(
         ctx.current_operation = None
         _thoth_signals._current_checkpoint_manager = None
         _thoth_signals._current_operation = None
-        if op_failure_type == "recoverable":
+        if op_failure_type == "recoverable" and is_background_kind:
             console.print(
                 f"\n[cyan]This failure is recoverable.[/cyan] "
                 f"Resume with: [bold]thoth resume {operation.id}[/bold]"
@@ -687,7 +715,12 @@ async def _execute_research(
     if not quiet and len(operation.output_paths) > 1 and "combined" not in operation.output_paths:
         console.print("\nTo generate a combined report, run with --combined flag")
 
-    if not quiet:
+    # P18: only emit operation-ID echo + status/list hints for background runs.
+    # Immediate runs have no resumable job; the user already has the result
+    # printed in front of them. `--project` and explicit persistence (Phase E
+    # `--out FILE`) still trigger checkpoint writes, but the hints are the
+    # background-mode UX.
+    if not quiet and is_background_kind:
         console.print(f"\nOperation ID: [bold]{operation.id}[/bold]")
         print_hint(f"thoth status {operation.id}", "Re-check later")
         print_hint("thoth list", "See recent runs")

--- a/src/thoth/sinks.py
+++ b/src/thoth/sinks.py
@@ -1,0 +1,123 @@
+"""P18 Phase E: output sinks for immediate-mode streaming.
+
+`MultiSink` fans `write(chunk)` to a list of text-mode IO handles. Files
+are opened lazily on first write so an aborted submit doesn't leave empty
+files lying around. `close()` is idempotent and never closes `sys.stdout`.
+
+CLI surface (wired in `cli_subcommands/_options.py:_RESEARCH_OPTIONS`):
+
+  --out -                stdout (default if no --out given)
+  --out PATH             file (replaces stdout)
+  --out -,PATH           comma-list — tee to both
+  --out - --out PATH     repeatable form — same as comma-list
+  --append               file opened in "a" mode instead of "w"
+
+Spec §5.3 + §5.7.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import IO
+
+
+class _LazyFileSink:
+    """File-backed sink that opens the underlying file only on first write."""
+
+    def __init__(self, path: Path, *, append: bool):
+        self._path = path
+        self._mode = "a" if append else "w"
+        self._handle: IO[str] | None = None
+
+    def write(self, chunk: str) -> None:
+        if self._handle is None:
+            self._handle = open(self._path, self._mode, encoding="utf-8")
+        self._handle.write(chunk)
+        self._handle.flush()
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+
+class _StdoutSink:
+    """stdout-backed sink. Never closes the underlying stream."""
+
+    def write(self, chunk: str) -> None:
+        sys.stdout.write(chunk)
+        sys.stdout.flush()
+
+    def close(self) -> None:
+        # Intentionally a no-op — sys.stdout outlives any single sink.
+        pass
+
+
+class MultiSink:
+    """Fans `write(chunk)` to a list of underlying sinks; idempotent close."""
+
+    def __init__(self, sinks: list[_LazyFileSink | _StdoutSink]):
+        self._sinks = sinks
+        self._closed = False
+
+    @classmethod
+    def from_specs(cls, specs: list[str], *, append: bool = False) -> MultiSink:
+        """Construct from a list of `--out` specs.
+
+        Each spec is one of:
+          * "-"           → stdout
+          * "PATH"        → file
+          * "X,Y,..."     → comma-separated list of either form (recursively split)
+
+        Empty `specs` defaults to stdout (matches existing behavior when no
+        `--out` is passed).
+        """
+        flat: list[str] = []
+        for spec in specs:
+            if "," in spec:
+                flat.extend(s.strip() for s in spec.split(",") if s.strip())
+            else:
+                flat.append(spec)
+
+        if not flat:
+            flat = ["-"]
+
+        sinks: list[_LazyFileSink | _StdoutSink] = []
+        seen_paths: set[Path] = set()
+        seen_stdout = False
+        for entry in flat:
+            if entry == "-":
+                if not seen_stdout:
+                    sinks.append(_StdoutSink())
+                    seen_stdout = True
+            else:
+                p = Path(entry).expanduser()
+                resolved = p.resolve() if p.exists() else p
+                if resolved in seen_paths:
+                    continue
+                seen_paths.add(resolved)
+                sinks.append(_LazyFileSink(p, append=append))
+        return cls(sinks)
+
+    def write(self, chunk: str) -> None:
+        if self._closed:
+            raise RuntimeError("MultiSink: write after close")
+        for sink in self._sinks:
+            sink.write(chunk)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for sink in self._sinks:
+            sink.close()
+        self._closed = True
+
+    def __enter__(self) -> MultiSink:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = ["MultiSink"]

--- a/tests/conftest_p16.py
+++ b/tests/conftest_p16.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
-from collections.abc import Callable
+import tempfile
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TypedDict
 
@@ -15,11 +17,11 @@ import pytest
 BASELINES_DIR = Path(__file__).parent / "baselines"
 
 
-def _scrub_home(s: str) -> str:
+def _scrub_home(s: str, home: str | None = None) -> str:
     """Replace user's home directory with <HOME> placeholder for portable baselines."""
-    home = os.path.expanduser("~")
-    if home and home != "/":
-        return s.replace(home, "<HOME>")
+    home_path = home or os.path.expanduser("~")
+    if home_path and home_path != "/":
+        return s.replace(home_path, "<HOME>")
     return s
 
 
@@ -41,15 +43,24 @@ def baseline() -> Callable[[str], BaselineRecord]:
 
 
 @pytest.fixture
-def run_thoth() -> Callable[[list[str]], tuple[int, str, str]]:
+def run_thoth() -> Iterator[Callable[[list[str]], tuple[int, str, str]]]:
+    home = Path(tempfile.mkdtemp(prefix="tp16", dir="/tmp"))
+
     def _run(argv: list[str]) -> tuple[int, str, str]:
         result = subprocess.run(
             [sys.executable, "-m", "thoth", *argv],
             capture_output=True,
             text=True,
             timeout=30,
-            env={"THOTH_TEST_MODE": "1", "PATH": "/usr/bin:/bin"},
+            env={"THOTH_TEST_MODE": "1", "PATH": "/usr/bin:/bin", "HOME": str(home)},
         )
-        return result.returncode, _scrub_home(result.stdout), _scrub_home(result.stderr)
+        return (
+            result.returncode,
+            _scrub_home(result.stdout, str(home)),
+            _scrub_home(result.stderr, str(home)),
+        )
 
-    return _run
+    try:
+        yield _run
+    finally:
+        shutil.rmtree(home, ignore_errors=True)

--- a/tests/extended/test_model_kind_runtime.py
+++ b/tests/extended/test_model_kind_runtime.py
@@ -58,8 +58,8 @@ def test_model_kind_matches_runtime_behavior(spec) -> None:
         # PerplexityProvider.submit raises NotImplementedError as of P18.
         pytest.skip("perplexity provider is not yet operational")
 
-    from thoth.providers import create_provider
     from thoth.config import ConfigManager
+    from thoth.providers import create_provider
 
     cm = ConfigManager()
     cm.load_all_layers({})
@@ -74,10 +74,7 @@ def test_model_kind_matches_runtime_behavior(spec) -> None:
     async def _exercise() -> dict:
         job_id = await provider.submit("ping", mode="_runtime_check_")
         status = await provider.check_status(job_id)
-        if (
-            spec.kind == "background"
-            and status.get("status") in ("running", "queued")
-        ):
+        if spec.kind == "background" and status.get("status") in ("running", "queued"):
             # Cancel before the deep-research job actually runs to completion
             # — the test only needed to confirm submission was async.
             try:

--- a/tests/extended/test_model_kind_runtime.py
+++ b/tests/extended/test_model_kind_runtime.py
@@ -1,0 +1,101 @@
+"""P18 Phase I: extended runtime contract tests.
+
+For each model in `KNOWN_MODELS`, hit the REAL provider API and verify the
+declared `kind` matches the model's actual API behavior:
+
+  * `kind == "immediate"` → first `check_status(submit())` returns `"completed"`
+    (single round-trip; no async polling required)
+  * `kind == "background"` → first `check_status(submit())` returns one of
+    `"running"`, `"queued"`, or `"completed"` (the latter only if the
+    upstream API was very fast). For background hits, we then `cancel()`
+    to limit cost.
+
+Gated by `@pytest.mark.extended`. Default `pytest` skips this entire
+module (`addopts = "-m 'not extended'"`); run explicitly with
+`uv run pytest -m extended` or `just test-extended` after exporting the
+required API keys.
+
+Cost target: <$0.10 per full run (small ping prompts; cancel before
+deep-research jobs run to completion).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from thoth.models import KNOWN_MODELS
+
+# Skip the entire module unless explicit `extended` marker is selected. The
+# `pytest.mark.extended` decorator ALSO does this, but the early skip avoids
+# importing/instantiating providers when the user hasn't opted in.
+pytestmark = pytest.mark.extended
+
+
+def _missing_keys_for(provider: str) -> list[str]:
+    needs = {
+        "openai": ["OPENAI_API_KEY"],
+        "perplexity": ["PERPLEXITY_API_KEY"],
+        "mock": [],
+    }.get(provider, [])
+    return [k for k in needs if not os.environ.get(k)]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    KNOWN_MODELS,
+    ids=lambda s: f"{s.provider}/{s.id}",
+)
+def test_model_kind_matches_runtime_behavior(spec) -> None:
+    """Submit a tiny ping; assert kind contract holds against the live API."""
+    missing = _missing_keys_for(spec.provider)
+    if missing:
+        pytest.skip(f"{spec.provider}: required env vars missing: {missing}")
+
+    if spec.provider == "perplexity":
+        # PerplexityProvider.submit raises NotImplementedError as of P18.
+        pytest.skip("perplexity provider is not yet operational")
+
+    from thoth.providers import create_provider
+    from thoth.config import ConfigManager
+
+    cm = ConfigManager()
+    cm.load_all_layers({})
+
+    mode_config = {
+        "provider": spec.provider,
+        "model": spec.id,
+        "kind": spec.kind,
+    }
+    provider = create_provider(spec.provider, cm, mode_config=mode_config)
+
+    async def _exercise() -> dict:
+        job_id = await provider.submit("ping", mode="_runtime_check_")
+        status = await provider.check_status(job_id)
+        if (
+            spec.kind == "background"
+            and status.get("status") in ("running", "queued")
+        ):
+            # Cancel before the deep-research job actually runs to completion
+            # — the test only needed to confirm submission was async.
+            try:
+                await provider.cancel(job_id)
+            except NotImplementedError:
+                pass
+        return status
+
+    status = asyncio.run(_exercise())
+
+    if spec.kind == "immediate":
+        assert status.get("status") == "completed", (
+            f"{spec.provider}/{spec.id} declared kind='immediate' but first "
+            f"check_status returned {status!r} — drift between thoth's "
+            f"KNOWN_MODELS registry and the upstream API."
+        )
+    else:  # background
+        assert status.get("status") in ("running", "queued", "completed"), (
+            f"{spec.provider}/{spec.id} declared kind='background' but first "
+            f"check_status returned {status!r}; expected running/queued/completed."
+        )

--- a/tests/test_builtin_modes_have_kind.py
+++ b/tests/test_builtin_modes_have_kind.py
@@ -1,0 +1,40 @@
+"""P18 Phase A: every builtin mode must declare an explicit `kind`.
+
+Substring sniffing (via `is_background_model`) is deprecated as a *resolution*
+path. This test prevents regressions where a new builtin lands without the
+field. See `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md`
+§4 Q12 and §5.3.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from thoth.config import BUILTIN_MODES
+
+VALID_KINDS = {"immediate", "background"}
+
+
+def _resolved_modes() -> list[tuple[str, dict]]:
+    """Skip alias stubs — they delegate to a real mode and don't carry kind themselves."""
+    return [
+        (name, cfg) for name, cfg in BUILTIN_MODES.items() if "_deprecated_alias_for" not in cfg
+    ]
+
+
+@pytest.mark.parametrize("name,cfg", sorted(_resolved_modes()))
+def test_builtin_declares_kind(name: str, cfg: dict) -> None:
+    assert "kind" in cfg, f"Builtin mode '{name}' missing required 'kind' field"
+    assert cfg["kind"] in VALID_KINDS, (
+        f"Builtin mode '{name}' has kind={cfg['kind']!r}; must be one of {sorted(VALID_KINDS)}"
+    )
+
+
+def test_at_least_one_immediate_and_one_background() -> None:
+    """Sanity: the 12-mode catalog has both kinds represented."""
+    kinds = {
+        cfg["kind"]
+        for cfg in BUILTIN_MODES.values()
+        if "kind" in cfg and "_deprecated_alias_for" not in cfg
+    }
+    assert kinds >= VALID_KINDS, f"Expected both kinds in builtins, got {kinds}"

--- a/tests/test_cancel_subcommand.py
+++ b/tests/test_cancel_subcommand.py
@@ -1,0 +1,90 @@
+"""P18 Phase G: `thoth cancel <op-id>` subcommand.
+
+Verifies the user-facing flow: load operation, call provider.cancel(),
+update checkpoint to cancelled status, exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from thoth.cli import cli
+from tests._fixture_helpers import run_thoth
+
+
+def test_cancel_subcommand_registered() -> None:
+    """`thoth cancel --help` returns 0 with usage text — the command is wired."""
+    from click.testing import CliRunner
+
+    r = CliRunner().invoke(cli, ["cancel", "--help"])
+    assert r.exit_code == 0
+    assert "cancel" in r.output.lower()
+
+
+def test_cancel_missing_operation_exits_6() -> None:
+    from click.testing import CliRunner
+
+    r = CliRunner().invoke(cli, ["cancel", "DOES-NOT-EXIST-123"])
+    assert r.exit_code == 6, r.output
+
+
+def test_cancel_existing_operation_marks_cancelled(
+    isolated_thoth_home: Path,
+    checkpoint_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: submit + async (background-kind) → cancel → checkpoint cancelled."""
+    monkeypatch.chdir(tmp_path)
+
+    # Submit a deep_research run async so it stays in the running state.
+    exit_code, stdout, stderr = run_thoth(
+        ["--mode", "deep_research", "cancel-test prompt", "--provider", "mock", "--async"],
+    )
+    assert exit_code == 0, f"submit failed: {stdout=!r} {stderr=!r}"
+    # Extract operation id from stdout (mock submit prints "Operation ID: <id>")
+    op_id = None
+    for line in (stdout + stderr).splitlines():
+        if "Operation ID:" in line:
+            op_id = line.split("Operation ID:", 1)[1].strip()
+            break
+    assert op_id, f"could not parse op id: {stdout!r}"
+
+    # Cancel
+    cancel_code, cancel_stdout, cancel_stderr = run_thoth(["cancel", op_id])
+    assert cancel_code == 0, f"cancel exit={cancel_code} {cancel_stdout=!r} {cancel_stderr=!r}"
+
+    # Checkpoint reflects cancelled status
+    checkpoint_file = checkpoint_dir / f"{op_id}.json"
+    assert checkpoint_file.exists()
+    data = json.loads(checkpoint_file.read_text())
+    assert data["status"] == "cancelled", f"checkpoint not cancelled: {data!r}"
+
+
+def test_cancel_already_completed_operation_is_idempotent(
+    isolated_thoth_home: Path,
+    checkpoint_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling a completed operation should be a no-op success."""
+    monkeypatch.chdir(tmp_path)
+
+    # Run a default mock op to completion (immediate kind, sync).
+    # THOTH_POLL_INTERVAL keeps the default polling loop fast under mock.
+    exit_code, stdout, stderr = run_thoth(
+        ["completed-test", "--provider", "mock"],
+        env_overrides={"THOTH_POLL_INTERVAL": "0.1"},
+    )
+    assert exit_code == 0
+
+    # Find the most recent checkpoint
+    checkpoints = sorted(checkpoint_dir.glob("*.json"))
+    assert checkpoints, f"no checkpoint created: {list(checkpoint_dir.iterdir())}"
+    op_id = checkpoints[-1].stem
+
+    cancel_code, _, _ = run_thoth(["cancel", op_id])
+    assert cancel_code == 0

--- a/tests/test_cancel_subcommand.py
+++ b/tests/test_cancel_subcommand.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 import pytest
 
-from thoth.cli import cli
 from tests._fixture_helpers import run_thoth
+from thoth.cli import cli
 
 
 def test_cancel_subcommand_registered() -> None:

--- a/tests/test_cli_regressions.py
+++ b/tests/test_cli_regressions.py
@@ -9,6 +9,10 @@ from click.testing import CliRunner
 from thoth.cli import cli
 
 
+def _mock_stream(prompt: str, mode: str = "default") -> str:
+    return f"# Mock streaming response (mode={mode})\n\nEcho: {prompt}\n\nDone."
+
+
 def _stub_run_research(monkeypatch):
     captured = {}
 
@@ -50,6 +54,118 @@ def test_bug_cli_001_research_fallback_forwards_global_options(
     assert captured["provider"] == "mock"
     assert captured["project"] == "regression"
     assert captured["async_mode"] is True
+
+
+def test_bare_prompt_forwards_leading_out_and_append(monkeypatch, tmp_path: Path) -> None:
+    captured = _stub_run_research(monkeypatch)
+    target = tmp_path / "answer.md"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--out", str(target), "--append", "--provider", "mock", "topic"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["prompt"] == "topic"
+    assert captured["provider"] == "mock"
+    assert captured["out_specs"] == (str(target),)
+    assert captured["append"] is True
+
+
+def test_bare_prompt_forwards_trailing_out_and_append(monkeypatch, tmp_path: Path) -> None:
+    captured = _stub_run_research(monkeypatch)
+    target = tmp_path / "answer.md"
+
+    result = CliRunner().invoke(
+        cli,
+        ["topic", "--provider", "mock", "--out", str(target), "--append"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["prompt"] == "topic"
+    assert captured["provider"] == "mock"
+    assert captured["out_specs"] == (str(target),)
+    assert captured["append"] is True
+
+
+def test_bare_prompt_leading_out_writes_stream_file(
+    isolated_thoth_home: Path, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "leading.md"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--out", str(target), "--provider", "mock", "leading prompt"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == ""
+    assert target.read_text() == _mock_stream("leading prompt")
+
+
+def test_bare_prompt_trailing_out_writes_stream_file(
+    isolated_thoth_home: Path, monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "trailing.md"
+
+    result = CliRunner().invoke(
+        cli,
+        ["trailing prompt", "--provider", "mock", "--out", str(target)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == ""
+    assert target.read_text() == _mock_stream("trailing prompt")
+
+
+def test_background_forwards_openai_cli_api_key(monkeypatch) -> None:
+    captured = _stub_run_research(monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "deep_research",
+            "openai key",
+            "--provider",
+            "openai",
+            "--api-key-openai",
+            "sk-test",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["provider"] == "openai"
+    assert captured["cli_api_keys"] == {
+        "openai": "sk-test",
+        "perplexity": None,
+        "mock": None,
+    }
+
+
+def test_background_forwards_perplexity_cli_api_key(monkeypatch) -> None:
+    captured = _stub_run_research(monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "deep_research",
+            "perplexity key",
+            "--provider",
+            "perplexity",
+            "--api-key-perplexity",
+            "pplx-test",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["provider"] == "perplexity"
+    assert captured["cli_api_keys"] == {
+        "openai": None,
+        "perplexity": "pplx-test",
+        "mock": None,
+    }
 
 
 def test_bug_cli_002_option_only_prompt_runs_research(monkeypatch) -> None:
@@ -192,3 +308,26 @@ def test_root_no_args_shows_help() -> None:
     assert "Usage:" in result.output
     assert "Run research:" in result.output
     assert "Manage thoth:" in result.output
+
+
+def test_command_error_shows_command_help_before_error() -> None:
+    result = CliRunner().invoke(cli, ["modes", "--kind", "immediate"])
+
+    assert result.exit_code == 2
+    assert "Usage:" in result.output
+    assert "List research modes with provider/model/kind." in result.output
+    assert "Commands:" in result.output
+    assert "list" in result.output
+    assert "Error: No such command '--kind'." in result.output
+    assert result.output.index("Usage:") < result.output.index("Error:")
+
+
+def test_leaf_command_error_shows_leaf_help_before_error() -> None:
+    result = CliRunner().invoke(cli, ["modes", "list", "--kind", "fast"])
+
+    assert result.exit_code == 2
+    assert "Usage:" in result.output
+    assert "List research modes." in result.output
+    assert "--kind [immediate|background]" in result.output
+    assert "Error: Invalid value for '--kind'" in result.output
+    assert result.output.index("Usage:") < result.output.index("Error:")

--- a/tests/test_immediate_path.py
+++ b/tests/test_immediate_path.py
@@ -15,11 +15,17 @@ arrives in Phase E alongside `provider.stream()`. Phase C ships the UX gates.
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from rich.console import Console
 
-from thoth.run import _poll_display
+from tests._fixture_helpers import run_thoth
+from tests.conftest import make_operation
+from thoth.context import AppContext
+from thoth.run import _execute_immediate, _poll_display
 
 
 def test_poll_display_yields_none_for_immediate_kind() -> None:
@@ -110,3 +116,91 @@ def test_should_show_spinner_short_circuits_for_immediate() -> None:
     # The spinner gate should NOT have been called for immediate runs — the
     # short-circuit happens above it.
     assert not mock_gate.called
+
+
+def test_immediate_stream_failure_does_not_double_fail_operation(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream failure already marked failed must not be failed a second time."""
+    monkeypatch.chdir(tmp_path)
+
+    exit_code, stdout, stderr = run_thoth(
+        ["permanent stream fail", "--provider", "mock"],
+        env_overrides={"THOTH_MOCK_BEHAVIOR": "permanent"},
+    )
+    combined = stdout + stderr
+
+    assert exit_code == 1, combined
+    assert "Mock permanent failure" in combined
+    assert "Invalid state transition" not in combined
+
+
+def test_immediate_falls_back_to_submit_get_result_when_stream_not_implemented(
+    stub_config,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class CheckpointStub:
+        def __init__(self) -> None:
+            self.saved_statuses: list[str] = []
+
+        async def save(self, operation) -> None:
+            self.saved_statuses.append(operation.status)
+
+    class OutputStub:
+        async def save_result(self, *args, **kwargs):
+            raise AssertionError("project-less immediate fallback must not save result files")
+
+    class FallbackProvider:
+        model = "fallback-model"
+
+        def __init__(self) -> None:
+            self.submitted: tuple[str, str, str | None] | None = None
+
+        async def stream(self, prompt, mode, system_prompt=None, verbose=False):
+            if False:
+                yield None
+            raise NotImplementedError("stream unavailable")
+
+        async def submit(self, prompt, mode, system_prompt=None, verbose=False):
+            self.submitted = (prompt, mode, system_prompt)
+            return "job-1"
+
+        async def get_result(self, job_id, verbose=False):
+            assert job_id == "job-1"
+            return "fallback content"
+
+    checkpoint = CheckpointStub()
+    provider = FallbackProvider()
+    operation = make_operation("research-fallback")
+
+    # ty doesn't honor structural typing for stub doubles; the runtime contract
+    # is duck-typed and explicit `cast` would just hide the same delta. Suppress
+    # arg-type for the call itself.
+    asyncio.run(
+        _execute_immediate(
+            operation=operation,
+            checkpoint_manager=checkpoint,  # ty: ignore[invalid-argument-type]
+            output_manager=OutputStub(),  # ty: ignore[invalid-argument-type]
+            config=stub_config,
+            mode_config={"system_prompt": "system text"},
+            providers={"mock": provider},
+            quiet=False,
+            verbose=False,
+            output_dir=None,
+            project=None,
+            mode="default",
+            prompt="fallback prompt",
+            out_specs=(),
+            append=False,
+            ctx=AppContext(config=stub_config),
+        )
+    )
+
+    assert capsys.readouterr().out == "fallback content"
+    assert provider.submitted == ("fallback prompt", "default", "system text")
+    assert operation.status == "completed"
+    assert operation.providers["mock"]["job_id"] == "job-1"
+    assert operation.output_paths == {}
+    assert checkpoint.saved_statuses == ["running", "completed"]

--- a/tests/test_immediate_path.py
+++ b/tests/test_immediate_path.py
@@ -1,0 +1,112 @@
+"""P18 Phase C: immediate-mode UX deltas.
+
+Confirms the user-visible Phase C value:
+
+  * `_poll_display(mode_cfg=immediate)` yields None (neither spinner nor
+    Progress bar engages)
+  * `_execute_research` does NOT print the trailing "Operation ID" + status
+    hints for immediate-kind operations
+  * `_execute_research` does NOT print the "Resume with: thoth resume" hint
+    on a recoverable failure for immediate-kind operations
+
+The full path split (skipping the polling loop entirely for immediate runs)
+arrives in Phase E alongside `provider.stream()`. Phase C ships the UX gates.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from rich.console import Console
+
+from thoth.run import _poll_display
+
+
+def test_poll_display_yields_none_for_immediate_kind() -> None:
+    """Declared `kind=immediate` → no progress UI at all."""
+    immediate_cfg = {"model": "o3", "kind": "immediate"}
+    with _poll_display(
+        quiet=False,
+        mode_model="o3",
+        verbose=False,
+        rich_console=Console(),
+        mode_cfg=immediate_cfg,
+    ) as display:
+        assert display is None
+
+
+def test_poll_display_yields_progress_for_background_no_tty() -> None:
+    """Background-kind in non-TTY (test stream) → Progress bar (legacy fallback)."""
+    background_cfg = {"model": "o3-deep-research", "kind": "background"}
+    # We can't easily simulate a TTY in tests; the spinner path requires it.
+    # Without TTY, _poll_display engages the Progress bar branch — verify it's
+    # not None, which is the salient difference from the immediate path.
+    with _poll_display(
+        quiet=False,
+        mode_model="o3-deep-research",
+        verbose=False,
+        rich_console=Console(),
+        mode_cfg=background_cfg,
+    ) as display:
+        assert display is not None  # Progress object
+
+
+def test_poll_display_legacy_no_mode_cfg_unchanged() -> None:
+    """Pre-P18 callers without mode_cfg: behavior unchanged."""
+    with _poll_display(
+        quiet=False,
+        mode_model="o3-deep-research",
+        verbose=False,
+        rich_console=Console(),
+    ) as display:
+        # Without mode_cfg, the model substring rule fires; non-TTY stream
+        # falls through to Progress bar (existing behavior).
+        assert display is not None
+
+
+def test_poll_display_legacy_no_mode_cfg_immediate_model() -> None:
+    """Pre-P18 caller with immediate-y model: still gets Progress (legacy)."""
+    with _poll_display(
+        quiet=False,
+        mode_model="o3",
+        verbose=False,
+        rich_console=Console(),
+    ) as display:
+        # Without mode_cfg the function defaults to model-only check; o3 is
+        # not a deep-research model → Progress bar fires (the pre-P18 path).
+        assert display is not None
+
+
+def test_should_show_spinner_used_by_poll_display_for_background_with_mode_cfg() -> None:
+    """When mode_cfg=background, the spinner gate is consulted."""
+    background_cfg = {"model": "o3-deep-research", "kind": "background"}
+    with patch("thoth.run.should_show_spinner", return_value=False) as mock_gate:
+        with _poll_display(
+            quiet=False,
+            mode_model="o3-deep-research",
+            verbose=False,
+            rich_console=Console(),
+            mode_cfg=background_cfg,
+        ):
+            pass
+    # Verify the gate was called — Phase C wired mode_cfg into the call.
+    assert mock_gate.called
+    call_kwargs = mock_gate.call_args.kwargs
+    assert call_kwargs.get("mode_cfg") == background_cfg
+
+
+def test_should_show_spinner_short_circuits_for_immediate() -> None:
+    """For immediate kind, _poll_display short-circuits without consulting the spinner gate."""
+    immediate_cfg = {"model": "o3", "kind": "immediate"}
+    with patch("thoth.run.should_show_spinner", return_value=False) as mock_gate:
+        with _poll_display(
+            quiet=False,
+            mode_model="o3",
+            verbose=False,
+            rich_console=Console(),
+            mode_cfg=immediate_cfg,
+        ) as display:
+            assert display is None
+    # The spinner gate should NOT have been called for immediate runs — the
+    # short-circuit happens above it.
+    assert not mock_gate.called

--- a/tests/test_json_envelopes.py
+++ b/tests/test_json_envelopes.py
@@ -36,6 +36,8 @@ JSON_COMMANDS: list[tuple[str, list[str], int]] = [
     # (Category G timing tests). The smoke-row below covers the resume
     # OPERATION_NOT_FOUND envelope.
     ("resume_missing_op", ["resume", "research-MISSING", "--json"], 6),
+    # P18 Phase G: cancel subcommand. Missing-op exits 6 with OPERATION_NOT_FOUND envelope.
+    ("cancel_missing_op", ["cancel", "research-MISSING", "--json"], 6),
     # T15: lint-meta coverage rows for `completion` (UNSUPPORTED_SHELL error
     # envelope) and `config edit` (success envelope; EDITOR=true monkeypatched
     # in the parametrize body).

--- a/tests/test_known_models_registry.py
+++ b/tests/test_known_models_registry.py
@@ -1,0 +1,72 @@
+"""P18 Phase A: KNOWN_MODELS is derived from BUILTIN_MODES.
+
+The registry is the single source of truth for "what models does thoth ship
+with, and what kind is each". Cross-mode kind conflicts (same (provider,
+model) declared with two different kinds across builtins) raise at import.
+
+See spec §5.3 / §4 Q2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from thoth.config import BUILTIN_MODES
+from thoth.errors import ThothError
+from thoth.models import KNOWN_MODELS, ModelSpec, derive_known_models
+
+
+def test_modelspec_shape() -> None:
+    spec = ModelSpec(id="o3", provider="openai", kind="immediate")
+    assert spec.id == "o3"
+    assert spec.provider == "openai"
+    assert spec.kind == "immediate"
+
+
+def test_known_models_is_a_list_of_modelspec() -> None:
+    assert isinstance(KNOWN_MODELS, list)
+    assert all(isinstance(m, ModelSpec) for m in KNOWN_MODELS)
+
+
+def test_known_models_unique_provider_model_pairs() -> None:
+    """Each (provider, model) appears at most once."""
+    keys = [(m.provider, m.id) for m in KNOWN_MODELS]
+    assert len(keys) == len(set(keys)), f"Duplicate (provider, model) pairs in KNOWN_MODELS: {keys}"
+
+
+def test_every_builtin_appears_in_known_models() -> None:
+    """Every (provider, model, kind) triple from a non-alias builtin is in the registry."""
+    triples = {(m.provider, m.id, m.kind) for m in KNOWN_MODELS}
+    for name, cfg in BUILTIN_MODES.items():
+        if "_deprecated_alias_for" in cfg:
+            continue
+        triple = (cfg["provider"], cfg["model"], cfg["kind"])
+        assert triple in triples, f"Builtin {name!r} triple {triple} missing from KNOWN_MODELS"
+
+
+def test_derive_rejects_cross_mode_kind_conflict() -> None:
+    """Two modes claiming the same (provider, model) with different kinds must raise."""
+    bogus_modes = {
+        "real_immediate": {"provider": "openai", "model": "o3", "kind": "immediate"},
+        "fake_background": {"provider": "openai", "model": "o3", "kind": "background"},
+    }
+    with pytest.raises(ThothError, match="Inconsistent kind"):
+        derive_known_models(bogus_modes)
+
+
+def test_derive_skips_alias_stubs() -> None:
+    """`_deprecated_alias_for` stubs don't carry provider/model/kind and must be skipped."""
+    modes_with_alias = {
+        "real": {"provider": "openai", "model": "o3", "kind": "immediate"},
+        "alias_to_real": {"_deprecated_alias_for": "real"},
+    }
+    specs = derive_known_models(modes_with_alias)
+    assert len(specs) == 1
+    assert specs[0].id == "o3"
+
+
+def test_derive_raises_on_missing_required_fields() -> None:
+    """Builtin missing provider/model/kind is a thoth bug; raise loudly."""
+    broken = {"oops": {"provider": "openai", "model": "o3"}}  # no kind
+    with pytest.raises(ThothError, match="missing"):
+        derive_known_models(broken)

--- a/tests/test_mode_aliases.py
+++ b/tests/test_mode_aliases.py
@@ -1,0 +1,57 @@
+"""P18 Phase D: `mini_research` → `quick_research` rename with deprecation alias.
+
+The old name keeps working for one minor; resolution emits a one-time
+DeprecationWarning per process. Removed in v4.0.0 (future P19).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from thoth.config import BUILTIN_MODES, ConfigManager
+
+
+def test_quick_research_is_a_real_builtin() -> None:
+    assert "quick_research" in BUILTIN_MODES
+    cfg = BUILTIN_MODES["quick_research"]
+    assert "_deprecated_alias_for" not in cfg
+    assert cfg["model"] == "o4-mini-deep-research"
+    assert cfg["kind"] == "background"
+
+
+def test_mini_research_is_an_alias_stub() -> None:
+    assert "mini_research" in BUILTIN_MODES
+    cfg = BUILTIN_MODES["mini_research"]
+    assert cfg.get("_deprecated_alias_for") == "quick_research"
+
+
+def test_get_mode_config_resolves_alias_to_target() -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({})
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cfg = cm.get_mode_config("mini_research")
+    # Resolved cfg matches quick_research
+    target = BUILTIN_MODES["quick_research"]
+    assert cfg["model"] == target["model"]
+    assert cfg["kind"] == target["kind"]
+    # Deprecation warning emitted
+    deprecation_msgs = [
+        str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert any("mini_research" in m and "quick_research" in m for m in deprecation_msgs), (
+        f"Expected DeprecationWarning mentioning the rename; got: {deprecation_msgs}"
+    )
+
+
+def test_get_mode_config_target_does_not_warn() -> None:
+    """Calling with the new name `quick_research` must not warn."""
+    cm = ConfigManager()
+    cm.load_all_layers({})
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cm.get_mode_config("quick_research")
+    deprecation_msgs = [
+        str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert not any("mini_research" in m for m in deprecation_msgs)

--- a/tests/test_mode_kind_mismatch.py
+++ b/tests/test_mode_kind_mismatch.py
@@ -1,0 +1,118 @@
+"""P18 Phase B: runtime mismatch detection at provider.submit().
+
+A mode declared `kind = "immediate"` cannot use a deep-research model — those
+models REQUIRE OpenAI's background submission flow. The check fires at the
+top of `OpenAIProvider.submit()`, BEFORE any HTTP call, so users see a
+config-edit suggestion instead of a confusing API error.
+
+The reverse case (declared `background` + non-deep-research model) is LEGAL —
+OpenAI lets you force-background any model via `background=True`. Not checked.
+
+See spec §5.6 + §4 Q1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from thoth.errors import ModeKindMismatchError, ThothError
+from thoth.providers.openai import OpenAIProvider
+
+
+@pytest.fixture
+def fake_openai_key(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-real")
+    return "sk-test-fake-not-real"
+
+
+def _provider(*, model: str, kind: str | None) -> OpenAIProvider:
+    """Construct an OpenAIProvider with the given (model, kind) combo.
+
+    No HTTP client is exercised — we never call the real submit network path,
+    only the validation gate which fires before any HTTP work.
+    """
+    config: dict = {"model": model}
+    if kind is not None:
+        config["kind"] = kind
+    return OpenAIProvider(api_key="sk-test-fake-not-real", config=config)
+
+
+def test_immediate_with_o3_deep_research_raises(fake_openai_key: str) -> None:
+    p = _provider(model="o3-deep-research", kind="immediate")
+    with pytest.raises(ModeKindMismatchError) as exc:
+        asyncio.run(p.submit("hello", mode="thinking"))
+    assert exc.value.declared_kind == "immediate"
+    assert exc.value.required_kind == "background"
+    assert exc.value.model == "o3-deep-research"
+    assert exc.value.mode_name == "thinking"
+
+
+def test_immediate_with_o4_mini_deep_research_raises(fake_openai_key: str) -> None:
+    p = _provider(model="o4-mini-deep-research", kind="immediate")
+    with pytest.raises(ModeKindMismatchError):
+        asyncio.run(p.submit("hello", mode="thinking"))
+
+
+def test_background_with_regular_model_does_not_raise(
+    fake_openai_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Force-background on a non-deep-research model is legal — must not raise."""
+    p = _provider(model="o3", kind="background")
+
+    # Make sure the validation gate accepts this combo. We replace the inner
+    # retry method so submit() doesn't actually hit OpenAI; the validation
+    # check runs first and we just need to confirm it doesn't raise.
+    async def fake_submit(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return "fake-job-id"
+
+    monkeypatch.setattr(p, "_submit_with_retry", fake_submit)
+    job_id = asyncio.run(p.submit("hello", mode="deep_research"))
+    assert job_id == "fake-job-id"
+
+
+def test_immediate_with_regular_model_does_not_raise(
+    fake_openai_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The happy case — immediate mode with a regular model."""
+    p = _provider(model="o3", kind="immediate")
+
+    async def fake_submit(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return "fake-job-id"
+
+    monkeypatch.setattr(p, "_submit_with_retry", fake_submit)
+    job_id = asyncio.run(p.submit("hello", mode="thinking"))
+    assert job_id == "fake-job-id"
+
+
+def test_no_kind_declared_does_not_raise(
+    fake_openai_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-P18 callers (no `kind` threaded through) must keep working — backwards compat."""
+    p = _provider(model="o3", kind=None)
+
+    async def fake_submit(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return "fake-job-id"
+
+    monkeypatch.setattr(p, "_submit_with_retry", fake_submit)
+    job_id = asyncio.run(p.submit("hello", mode="default"))
+    assert job_id == "fake-job-id"
+
+
+def test_error_carries_user_facing_suggestion(fake_openai_key: str) -> None:
+    p = _provider(model="o3-deep-research", kind="immediate")
+    with pytest.raises(ModeKindMismatchError) as exc:
+        asyncio.run(p.submit("hello", mode="thinking"))
+    err = exc.value
+    assert "thinking" in err.message
+    assert "o3-deep-research" in err.message
+    assert err.suggestion is not None
+    assert "[modes.thinking]" in err.suggestion
+    assert "kind" in err.suggestion
+
+
+def test_error_subclasses_thotherror(fake_openai_key: str) -> None:
+    p = _provider(model="o3-deep-research", kind="immediate")
+    with pytest.raises(ThothError):
+        asyncio.run(p.submit("hello", mode="thinking"))

--- a/tests/test_modes_kind_filter.py
+++ b/tests/test_modes_kind_filter.py
@@ -1,0 +1,65 @@
+"""P18 Phase D: `thoth modes --kind <immediate|background>` filter.
+
+The filter applies to both the JSON envelope path (`get_modes_list_data`) and
+the Rich-rendering CLI path. Tab-completion uses the dead-code `mode_kind`
+completer in `completion/sources.py:79` (left as P18 forward-compat by PR3).
+
+Spec §10 acceptance: `thoth modes --kind immediate` filters; tab-complete
+returns `["immediate", "background"]`.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from thoth.cli import cli
+from thoth.completion.sources import mode_kind as mode_kind_completer
+from thoth.modes_cmd import get_modes_list_data
+
+
+def test_get_modes_list_data_filters_immediate() -> None:
+    data = get_modes_list_data(name=None, source="all", show_secrets=False, kind="immediate")
+    assert data["modes"], "expected at least one immediate mode"
+    assert all(m["kind"] == "immediate" for m in data["modes"])
+
+
+def test_get_modes_list_data_filters_background() -> None:
+    data = get_modes_list_data(name=None, source="all", show_secrets=False, kind="background")
+    assert data["modes"], "expected at least one background mode"
+    assert all(m["kind"] == "background" for m in data["modes"])
+
+
+def test_get_modes_list_data_no_filter_returns_all() -> None:
+    data = get_modes_list_data(name=None, source="all", show_secrets=False)
+    kinds = {m["kind"] for m in data["modes"]}
+    assert "immediate" in kinds
+    assert "background" in kinds
+
+
+def test_modes_list_cli_with_kind_immediate() -> None:
+    """`thoth modes list --kind immediate --json` returns only immediate modes."""
+    r = CliRunner().invoke(cli, ["modes", "list", "--kind", "immediate", "--json"])
+    assert r.exit_code == 0, r.output
+    import json
+
+    payload = json.loads(r.output)
+    modes = payload["data"]["modes"]
+    assert modes
+    assert all(m["kind"] == "immediate" for m in modes)
+
+
+def test_modes_list_cli_invalid_kind_value_exits_2() -> None:
+    r = CliRunner().invoke(cli, ["modes", "list", "--kind", "fast"])
+    assert r.exit_code == 2, r.output
+
+
+def test_mode_kind_completer_offers_both_values() -> None:
+    """The dead-code completer in completion/sources.py:79 is now wired."""
+    candidates = mode_kind_completer(None, None, "")
+    assert "immediate" in candidates
+    assert "background" in candidates
+
+
+def test_mode_kind_completer_filters_by_prefix() -> None:
+    candidates = mode_kind_completer(None, None, "im")
+    assert candidates == ["immediate"]

--- a/tests/test_output_sinks.py
+++ b/tests/test_output_sinks.py
@@ -1,0 +1,90 @@
+"""P18 Phase E: MultiSink — fans write(chunk) to a list of IO[str] handles.
+
+Lazy file open (don't truncate before first chunk arrives), ordered close
+in finally, supports stdout + file + tee + append.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from thoth.sinks import MultiSink
+
+
+def test_stdout_only(capsys) -> None:
+    sink = MultiSink.from_specs(["-"])
+    sink.write("hello ")
+    sink.write("world")
+    sink.close()
+    captured = capsys.readouterr()
+    assert captured.out == "hello world"
+
+
+def test_file_only_truncates_by_default(tmp_path: Path) -> None:
+    target = tmp_path / "out.md"
+    target.write_text("PRE-EXISTING")
+    sink = MultiSink.from_specs([str(target)])
+    sink.write("fresh content")
+    sink.close()
+    assert target.read_text() == "fresh content"
+
+
+def test_file_appends_when_requested(tmp_path: Path) -> None:
+    target = tmp_path / "out.md"
+    target.write_text("EXISTING\n")
+    sink = MultiSink.from_specs([str(target)], append=True)
+    sink.write("appended")
+    sink.close()
+    assert target.read_text() == "EXISTING\nappended"
+
+
+def test_tee_to_stdout_and_file(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "tee.md"
+    sink = MultiSink.from_specs(["-", str(target)])
+    sink.write("teed")
+    sink.close()
+    assert target.read_text() == "teed"
+    assert capsys.readouterr().out == "teed"
+
+
+def test_comma_list_parsing(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "comma.md"
+    sink = MultiSink.from_specs([f"-,{target}"])
+    sink.write("via-comma")
+    sink.close()
+    assert target.read_text() == "via-comma"
+    assert capsys.readouterr().out == "via-comma"
+
+
+def test_file_opened_lazily(tmp_path: Path) -> None:
+    """If we never write, the file is never opened — no empty file left behind."""
+    target = tmp_path / "lazy.md"
+    sink = MultiSink.from_specs([str(target)])
+    sink.close()  # no writes
+    assert not target.exists()
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "idem.md"
+    sink = MultiSink.from_specs([str(target)])
+    sink.write("once")
+    sink.close()
+    sink.close()  # second close must not raise
+    assert target.read_text() == "once"
+
+
+def test_default_when_no_specs_is_stdout(capsys) -> None:
+    sink = MultiSink.from_specs([])  # empty list = stdout
+    sink.write("default")
+    sink.close()
+    assert capsys.readouterr().out == "default"
+
+
+def test_does_not_close_stdout(tmp_path: Path) -> None:
+    """Even after close, sys.stdout must remain usable."""
+    sink = MultiSink.from_specs(["-"])
+    sink.write("a")
+    sink.close()
+    # If we accidentally closed sys.stdout, this would raise ValueError.
+    sys.stdout.write("")  # no exception means stdout still open

--- a/tests/test_p16_pr2_ask.py
+++ b/tests/test_p16_pr2_ask.py
@@ -18,6 +18,10 @@ def _stub_run_research(monkeypatch):
     return captured
 
 
+def _mock_stream(prompt: str, mode: str = "thinking") -> str:
+    return f"# Mock streaming response (mode={mode})\n\nEcho: {prompt}\n\nDone."
+
+
 # Category A: ask happy paths
 
 
@@ -70,6 +74,141 @@ def test_ask_subcommand_mode_wins_over_group_mode(monkeypatch):
     )
     assert r.exit_code == 0, r.output
     assert captured["mode"] == "deep_research"
+
+
+def test_ask_forwards_out_and_append_to_research_runner(monkeypatch, tmp_path):
+    captured = _stub_run_research(monkeypatch)
+    target = tmp_path / "answer.md"
+
+    r = CliRunner().invoke(
+        cli,
+        ["ask", "topic", "--out", str(target), "--append"],
+    )
+
+    assert r.exit_code == 0, r.output
+    assert captured["out_specs"] == (str(target),)
+    assert captured["append"] is True
+
+
+def test_ask_out_file_writes_streamed_mock_response(isolated_thoth_home, monkeypatch, tmp_path):
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "p18-smoke.md"
+    expected = _mock_stream("test 1")
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "ask",
+            "test 1",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            str(target),
+        ],
+    )
+
+    assert r.exit_code == 0, r.output
+    assert r.output == ""
+    assert target.read_text() == expected
+
+
+def test_ask_out_comma_list_tees_to_stdout_and_file(isolated_thoth_home, monkeypatch, tmp_path):
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "p18-tee.md"
+    expected = _mock_stream("test 2 teed")
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "ask",
+            "test 2 teed",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            f"-,{target}",
+        ],
+    )
+
+    assert r.exit_code == 0, r.output
+    assert r.output == expected
+    assert target.read_text() == expected
+
+
+def test_ask_out_repeatable_form_tees_to_stdout_and_file(
+    isolated_thoth_home, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "p18-tee2.md"
+    expected = _mock_stream("test 3")
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "ask",
+            "test 3",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            "-",
+            "--out",
+            str(target),
+        ],
+    )
+
+    assert r.exit_code == 0, r.output
+    assert r.output == expected
+    assert target.read_text() == expected
+
+
+def test_ask_out_append_concatenates_second_run(isolated_thoth_home, monkeypatch, tmp_path):
+    monkeypatch.setenv("MOCK_API_KEY", "test")
+    target = tmp_path / "p18-append.md"
+    target.write_text("stale")
+
+    first = _mock_stream("first run")
+    first_result = CliRunner().invoke(
+        cli,
+        [
+            "ask",
+            "first run",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            str(target),
+        ],
+    )
+
+    assert first_result.exit_code == 0, first_result.output
+    assert first_result.output == ""
+    assert target.read_text() == first
+
+    second = _mock_stream("second run")
+    second_result = CliRunner().invoke(
+        cli,
+        [
+            "ask",
+            "second run",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            str(target),
+            "--append",
+        ],
+    )
+
+    assert second_result.exit_code == 0, second_result.output
+    assert second_result.output == ""
+    assert target.read_text() == first + second
 
 
 # Category G: ask mutex tests

--- a/tests/test_p16_pr2_options_decorator.py
+++ b/tests/test_p16_pr2_options_decorator.py
@@ -8,10 +8,12 @@ from click.testing import CliRunner
 from thoth.cli_subcommands._options import _RESEARCH_OPTIONS, _research_options
 
 
-def test_research_options_decorator_adds_all_21_research_flags():
+def test_research_options_decorator_adds_all_research_flags():
     # Catches accidental additions/removals in _RESEARCH_OPTIONS.
-    assert len(_RESEARCH_OPTIONS) == 21, (
-        f"expected 21 research-options entries, got {len(_RESEARCH_OPTIONS)}"
+    # P18 Phase E added --out (repeatable) and --append; flag count is 23.
+    assert len(_RESEARCH_OPTIONS) == 23, (
+        f"expected 23 research-options entries (21 from PR2 + 2 from P18), "
+        f"got {len(_RESEARCH_OPTIONS)}"
     )
 
     @click.command()
@@ -20,6 +22,13 @@ def test_research_options_decorator_adds_all_21_research_flags():
         click.echo("ok")
 
     out = CliRunner().invoke(victim, ["--help"]).output
-    # Spot-check 5 representative options from across the stack
-    for opt in ("--mode", "--prompt-file", "--provider", "--api-key-openai", "--pick-model"):
+    # Spot-check 6 representative options from across the stack
+    for opt in (
+        "--mode",
+        "--prompt-file",
+        "--provider",
+        "--api-key-openai",
+        "--pick-model",
+        "--out",  # P18
+    ):
         assert opt in out, f"expected {opt} in --help output, got: {out}"

--- a/tests/test_pick_model.py
+++ b/tests/test_pick_model.py
@@ -6,7 +6,14 @@ from thoth.cli import cli
 def test_pick_model_rejected_on_deep_research():
     r = CliRunner().invoke(cli, ["--pick-model", "deep_research", "some prompt"])
     assert r.exit_code != 0
-    assert "only supported for quick" in r.output or "only supported for immediate" in r.output
+    # P18: error wording references declared `kind` rather than the model
+    # substring heuristic. Accept both legacy and new wording during the
+    # transition.
+    assert (
+        "only supported for quick" in r.output
+        or "only supported for immediate" in r.output
+        or "kind='immediate'" in r.output
+    )
 
 
 def test_pick_model_rejected_on_exploration():

--- a/tests/test_progress_gating.py
+++ b/tests/test_progress_gating.py
@@ -1,0 +1,123 @@
+"""P18 Phase C: progress display suppression for immediate-kind runs.
+
+Today (pre-P18) `should_show_spinner` returns False for non-deep-research
+models, but the unified `_poll_display` falls through to a `rich.Progress`
+bar for those cases. After P18, immediate-kind runs see NEITHER spinner NOR
+Progress bar.
+
+See spec §5.7 + Phase C in the plan.
+"""
+
+from __future__ import annotations
+
+import io
+
+from thoth.progress import should_show_spinner
+
+
+class _FakeTTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_should_show_spinner_false_for_immediate_mode_cfg() -> None:
+    """Immediate mode_cfg suppresses spinner regardless of model substring."""
+    tty = _FakeTTY()
+    immediate_cfg = {"model": "o3-deep-research", "kind": "immediate"}
+    # Even with a deep-research model, declared immediate kind wins → no spinner
+    assert (
+        should_show_spinner(
+            model=immediate_cfg["model"],
+            async_mode=False,
+            verbose=False,
+            stream=tty,
+            mode_cfg=immediate_cfg,
+        )
+        is False
+    )
+
+
+def test_should_show_spinner_true_for_background_mode_cfg_in_tty() -> None:
+    """Background kind + TTY + sync + non-verbose → spinner engages (existing behavior)."""
+    tty = _FakeTTY()
+    background_cfg = {"model": "o3-deep-research", "kind": "background"}
+    assert (
+        should_show_spinner(
+            model=background_cfg["model"],
+            async_mode=False,
+            verbose=False,
+            stream=tty,
+            mode_cfg=background_cfg,
+        )
+        is True
+    )
+
+
+def test_should_show_spinner_legacy_callers_unchanged() -> None:
+    """Callers without mode_cfg keep the pre-P18 model-only gate."""
+    tty = _FakeTTY()
+    # No mode_cfg passed; falls back to is_background_model substring
+    assert (
+        should_show_spinner(
+            model="o3-deep-research",
+            async_mode=False,
+            verbose=False,
+            stream=tty,
+        )
+        is True
+    )
+    assert (
+        should_show_spinner(
+            model="o3",
+            async_mode=False,
+            verbose=False,
+            stream=tty,
+        )
+        is False
+    )
+
+
+def test_should_show_spinner_async_overrides_immediate_or_background() -> None:
+    """`--async` always wins — user wants to background and exit, not watch."""
+    tty = _FakeTTY()
+    cfg = {"model": "o3-deep-research", "kind": "background"}
+    assert (
+        should_show_spinner(
+            model=cfg["model"],
+            async_mode=True,
+            verbose=False,
+            stream=tty,
+            mode_cfg=cfg,
+        )
+        is False
+    )
+
+
+def test_should_show_spinner_verbose_overrides() -> None:
+    tty = _FakeTTY()
+    cfg = {"model": "o3-deep-research", "kind": "background"}
+    assert (
+        should_show_spinner(
+            model=cfg["model"],
+            async_mode=False,
+            verbose=True,
+            stream=tty,
+            mode_cfg=cfg,
+        )
+        is False
+    )
+
+
+def test_should_show_spinner_non_tty_returns_false() -> None:
+    pipe = io.StringIO()  # no isatty() → False
+    cfg = {"model": "o3-deep-research", "kind": "background"}
+    assert (
+        should_show_spinner(
+            model=cfg["model"],
+            async_mode=False,
+            verbose=False,
+            stream=pipe,
+            mode_cfg=cfg,
+        )
+        is False
+    )

--- a/tests/test_provider_cancel.py
+++ b/tests/test_provider_cancel.py
@@ -1,0 +1,86 @@
+"""P18 Phase G: provider.cancel() implementations.
+
+Mock cancel hermetically; OpenAI cancel against monkeypatched client (no
+real HTTP). PerplexityProvider keeps the inherited NotImplementedError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from thoth.providers.mock import MockProvider
+from thoth.providers.openai import OpenAIProvider
+from thoth.providers.perplexity import PerplexityProvider
+
+
+def test_mock_cancel_pops_job_and_returns_cancelled() -> None:
+    mock = MockProvider(name="mock", delay=0.0, api_key="mock-test")
+
+    async def _flow():
+        job_id = await mock.submit("ping", mode="default")
+        result = await mock.cancel(job_id)
+        return job_id, result
+
+    job_id, result = asyncio.run(_flow())
+    assert result["status"] == "cancelled"
+    assert "cancelled by user" in result["error"]
+    assert job_id not in mock.jobs
+
+
+def test_openai_cancel_calls_responses_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the cancel call hits client.responses.cancel and maps the result."""
+    p = OpenAIProvider(api_key="sk-test", config={"model": "o3-deep-research"})
+    p.jobs["job-abc"] = {"response": None, "background": True, "created_at": None}
+
+    fake_response = type("FakeResp", (), {"status": "cancelled", "id": "job-abc"})()
+
+    captured: dict = {}
+
+    async def fake_cancel(job_id: str):
+        captured["job_id"] = job_id
+        return fake_response
+
+    # Replace the client.responses.cancel method
+    monkeypatch.setattr(p.client.responses, "cancel", fake_cancel)
+
+    result = asyncio.run(p.cancel("job-abc"))
+    assert captured["job_id"] == "job-abc"
+    assert result["status"] == "cancelled"
+
+
+def test_openai_cancel_completed_job_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the upstream job already completed, cancel returns 'completed' not error."""
+    p = OpenAIProvider(api_key="sk-test", config={"model": "o3-deep-research"})
+    p.jobs["job-done"] = {"response": None, "background": True, "created_at": None}
+
+    fake_response = type("FakeResp", (), {"status": "completed", "id": "job-done"})()
+
+    async def fake_cancel(job_id: str):
+        return fake_response
+
+    monkeypatch.setattr(p.client.responses, "cancel", fake_cancel)
+
+    result = asyncio.run(p.cancel("job-done"))
+    assert result["status"] == "completed"
+
+
+def test_openai_cancel_handles_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    p = OpenAIProvider(api_key="sk-test", config={"model": "o3-deep-research"})
+    p.jobs["job-broken"] = {"response": None, "background": True, "created_at": None}
+
+    async def fake_cancel(job_id: str):
+        raise RuntimeError("upstream API broke")
+
+    monkeypatch.setattr(p.client.responses, "cancel", fake_cancel)
+
+    result = asyncio.run(p.cancel("job-broken"))
+    assert result["status"] == "permanent_error"
+    assert "upstream API broke" in result["error"]
+
+
+def test_perplexity_cancel_raises_not_implemented() -> None:
+    p = PerplexityProvider(api_key="key", config={"model": "sonar-deep-research"})
+    with pytest.raises(NotImplementedError, match="PerplexityProvider"):
+        asyncio.run(p.cancel("any-job"))

--- a/tests/test_provider_stream_contract.py
+++ b/tests/test_provider_stream_contract.py
@@ -1,0 +1,60 @@
+"""P18 Phase E: provider.stream() contract.
+
+Mock provider yields deterministic chunks; aggregating them must equal the
+non-streaming get_result. OpenAI provider's stream impl is exercised in the
+extended suite (Phase I) since it requires real API or VCR cassettes.
+
+Spec §5.3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from thoth.providers.base import ResearchProvider, StreamEvent
+from thoth.providers.mock import MockProvider
+
+
+def test_stream_event_carries_kind_and_text() -> None:
+    e = StreamEvent(kind="text", text="hello")
+    assert e.kind == "text"
+    assert e.text == "hello"
+
+
+def test_base_stream_raises_not_implemented() -> None:
+    p = ResearchProvider(api_key="any")
+
+    async def _consume() -> list[StreamEvent]:
+        return [event async for event in p.stream("prompt", "default")]
+
+    with pytest.raises(NotImplementedError, match="ResearchProvider"):
+        asyncio.run(_consume())
+
+
+def test_mock_stream_yields_deterministic_chunks() -> None:
+    """MockProvider.stream() yields a fixed sequence; aggregating reproduces the prompt-echo."""
+    mock = MockProvider(name="mock", delay=0.0, api_key="mock-test")
+
+    async def _consume() -> list[StreamEvent]:
+        return [event async for event in mock.stream("hello world", "default")]
+
+    events = asyncio.run(_consume())
+    assert events, "MockProvider.stream() must yield at least one event"
+    assert all(isinstance(e, StreamEvent) for e in events)
+    text_events = [e for e in events if e.kind == "text"]
+    aggregated = "".join(e.text for e in text_events)
+    # Mock echoes the prompt somewhere in its output
+    assert "hello world" in aggregated
+
+
+def test_mock_stream_emits_done_event_last() -> None:
+    """The final event has kind='done' so callers can detect end-of-stream."""
+    mock = MockProvider(name="mock", delay=0.0, api_key="mock-test")
+
+    async def _consume() -> list[StreamEvent]:
+        return [event async for event in mock.stream("prompt", "default")]
+
+    events = asyncio.run(_consume())
+    assert events[-1].kind == "done"

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -24,11 +24,17 @@ def test_recoverable_failure_resume_reconnects_and_completes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """RES-01: Recoverable failure → resume reconnects and completes."""
+    """RES-01: Recoverable failure (background-kind) → resume reconnects and completes.
+
+    P18: the recoverable-failure resume hint only fires for background-kind
+    runs (immediate-kind has no upstream job to reattach to). This test uses
+    `--mode deep_research` to exercise the resumable path that the hint
+    targets.
+    """
     monkeypatch.chdir(tmp_path)
 
     exit_code, stdout, stderr = run_thoth(
-        ["res01 first", "--provider", "mock"],
+        ["--mode", "deep_research", "res01 first", "--provider", "mock"],
         env_overrides={"THOTH_MOCK_BEHAVIOR": "flake:10", "THOTH_POLL_INTERVAL": "0.1"},
     )
     combined = stdout + stderr

--- a/tests/test_thoth_test_cli.py
+++ b/tests/test_thoth_test_cli.py
@@ -466,3 +466,101 @@ def test_rerun_hint_uses_id_not_t(thoth_test_mod, tmp_path, monkeypatch, capsys)
     assert "--id FAIL-1" in out
     assert "--last-failed" in out
     assert "-t FAIL-1" not in out
+
+
+def test_interactive_runner_pins_uv_cache_dir(thoth_test_mod, monkeypatch):
+    captured = {}
+
+    class FakeChild:
+        before = ""
+        exitstatus = 0
+        signalstatus = None
+
+        def expect(self, pattern, timeout=None):
+            return 0
+
+        def isalive(self):
+            return False
+
+        def close(self, force=False):
+            return None
+
+    def fake_spawn(command, args=None, env=None, **kwargs):
+        captured["env"] = env or {}
+        return FakeChild()
+
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+    monkeypatch.setattr(thoth_test_mod.pexpect, "spawn", fake_spawn)
+
+    runner = thoth_test_mod.InteractiveTestRunner()
+    result = runner.run_interactive_test(
+        thoth_test_mod.TestCase(
+            test_id="INT-UV",
+            description="interactive uv cache",
+            command=["./thoth", "-i"],
+            test_type="interactive",
+        )
+    )
+
+    assert result.passed
+    assert captured["env"]["UV_CACHE_DIR"] == str(pathlib.Path.home() / ".cache" / "uv")
+
+
+def test_validate_file_contents_checks_recent_matching_files(thoth_test_mod, tmp_path):
+    target = tmp_path / "answer.md"
+    target.write_text("# Mock streaming response\n\nEcho: test output\n")
+
+    passed, matched, error = thoth_test_mod.validate_file_contents(
+        {"answer.md": [r"# Mock streaming response", r"Echo: test output"]},
+        since=0.0,
+        base=tmp_path,
+    )
+
+    assert passed
+    assert matched == [target]
+    assert error == ""
+
+
+def test_validate_file_contents_reports_missing_pattern(thoth_test_mod, tmp_path):
+    target = tmp_path / "answer.md"
+    target.write_text("wrong content")
+
+    passed, matched, error = thoth_test_mod.validate_file_contents(
+        {"answer.md": [r"Echo: test output"]},
+        since=0.0,
+        base=tmp_path,
+    )
+
+    assert not passed
+    assert matched == [target]
+    assert "Missing content pattern" in error
+
+
+def test_validate_file_content_absence_reports_forbidden_pattern(thoth_test_mod, tmp_path):
+    target = tmp_path / "answer.md"
+    target.write_text("---\noperation_id: op_test\n---\n\n# Mock Research Results\n")
+
+    passed, matched, error = thoth_test_mod.validate_file_content_absence(
+        {"answer.md": [r"operation_id:"]},
+        since=0.0,
+        base=tmp_path,
+    )
+
+    assert not passed
+    assert matched == [target]
+    assert "Unexpected content pattern" in error
+
+
+def test_validate_file_content_absence_allows_missing_pattern(thoth_test_mod, tmp_path):
+    target = tmp_path / "answer.md"
+    target.write_text("# Mock Research Results\n")
+
+    passed, matched, error = thoth_test_mod.validate_file_content_absence(
+        {"answer.md": [r"operation_id:"]},
+        since=0.0,
+        base=tmp_path,
+    )
+
+    assert passed
+    assert matched == [target]
+    assert error == ""

--- a/tests/test_user_mode_kind_warning.py
+++ b/tests/test_user_mode_kind_warning.py
@@ -1,0 +1,87 @@
+"""P18 Phase H: warn-once when a user-defined mode is missing `kind`.
+
+User TOMLs should declare `kind` explicitly (canonical) or pre-existing
+modes get a deprecation-style warning at config load. The error form is
+deferred to v4.0.0 (future P19); for now, the substring fallback in
+`mode_kind` keeps things working but the warning nudges migration.
+
+Spec §4 Q3 + Phase H in the plan.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from thoth.config import ConfigManager
+
+
+def _write_user_toml(tmp: Path, content: str) -> Path:
+    p = tmp / "thoth.toml"
+    p.write_text(content)
+    return p
+
+
+def test_user_mode_missing_kind_warns(tmp_path: Path) -> None:
+    cfg_path = _write_user_toml(
+        tmp_path,
+        """\
+version = "2.0"
+
+[modes.my_custom]
+provider = "openai"
+model = "o3"
+description = "user mode without kind"
+""",
+    )
+    cm = ConfigManager(config_path=cfg_path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cm.load_all_layers({})
+    msgs = [str(w.message) for w in caught]
+    assert any("my_custom" in m and "kind" in m for m in msgs), (
+        f"Expected warn-once on user mode missing kind; got: {msgs}"
+    )
+
+
+def test_user_mode_with_kind_does_not_warn(tmp_path: Path) -> None:
+    cfg_path = _write_user_toml(
+        tmp_path,
+        """\
+version = "2.0"
+
+[modes.my_custom]
+provider = "openai"
+model = "o3"
+kind = "immediate"
+description = "user mode with kind"
+""",
+    )
+    cm = ConfigManager(config_path=cfg_path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cm.load_all_layers({})
+    msgs = [str(w.message) for w in caught]
+    # No P18-kind warning for this user mode
+    assert not any("my_custom" in m and "kind" in m for m in msgs), (
+        f"Unexpected warning for fully-declared user mode: {msgs}"
+    )
+
+
+def test_builtin_modes_do_not_trigger_user_kind_warning(tmp_path: Path) -> None:
+    """Builtins always declare kind — they must NOT trigger the user-mode warning."""
+    cfg_path = _write_user_toml(
+        tmp_path,
+        """\
+version = "2.0"
+""",
+    )
+    cm = ConfigManager(config_path=cfg_path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cm.load_all_layers({})
+    msgs = [str(w.message) for w in caught]
+    # No "missing kind" warnings should fire — builtins all declare it
+    assert not any("missing" in m and "kind" in m for m in msgs), (
+        f"Builtin should not trigger missing-kind warning; got: {msgs}"
+    )

--- a/thoth_test
+++ b/thoth_test
@@ -136,6 +136,9 @@ class TestCase:
     not_expected_stdout_patterns: list[str] = field(default_factory=list)
     not_expected_stderr_patterns: list[str] = field(default_factory=list)
     expected_files: list[str] = field(default_factory=list)
+    not_expected_files: list[str] = field(default_factory=list)
+    expected_file_content_patterns: dict[str, list[str]] = field(default_factory=dict)
+    not_expected_file_content_patterns: dict[str, list[str]] = field(default_factory=dict)
     timeout: int = TEST_TIMEOUT
     cleanup_files: list[str] = field(default_factory=list)
     skip: bool = False
@@ -301,6 +304,82 @@ def validate_file_creation(
     return True, created_files, ""
 
 
+def validate_file_absence(
+    not_expected_files: list[str],
+    since: float = 0.0,
+    base: Path = Path("."),
+) -> tuple[bool, list[Path], str]:
+    """Check that matching files were not created after ``since``."""
+    unexpected_files = []
+
+    for file_pattern in not_expected_files:
+        matching_files = [p for p in base.glob(file_pattern) if p.stat().st_mtime >= since]
+        unexpected_files.extend(matching_files)
+
+    if unexpected_files:
+        return (
+            False,
+            unexpected_files,
+            f"Unexpected files created: {', '.join(str(p) for p in unexpected_files)}",
+        )
+
+    return True, [], ""
+
+
+def validate_file_contents(
+    expected_file_content_patterns: dict[str, list[str]],
+    since: float = 0.0,
+    base: Path = Path("."),
+) -> tuple[bool, list[Path], str]:
+    """Check that matching files contain all required regex patterns."""
+    matched_files: list[Path] = []
+
+    for file_pattern, content_patterns in expected_file_content_patterns.items():
+        matching_files = [p for p in base.glob(file_pattern) if p.stat().st_mtime >= since]
+        if not matching_files:
+            return False, matched_files, f"Missing expected files for content check: {file_pattern}"
+
+        for file_path in matching_files:
+            matched_files.append(file_path)
+            content = file_path.read_text(encoding="utf-8")
+            for content_pattern in content_patterns:
+                if not re.search(content_pattern, content, re.MULTILINE | re.DOTALL):
+                    return (
+                        False,
+                        matched_files,
+                        f"Missing content pattern {content_pattern!r} in {file_path}",
+                    )
+
+    return True, matched_files, ""
+
+
+def validate_file_content_absence(
+    not_expected_file_content_patterns: dict[str, list[str]],
+    since: float = 0.0,
+    base: Path = Path("."),
+) -> tuple[bool, list[Path], str]:
+    """Check that matching files do not contain forbidden regex patterns."""
+    matched_files: list[Path] = []
+
+    for file_pattern, content_patterns in not_expected_file_content_patterns.items():
+        matching_files = [p for p in base.glob(file_pattern) if p.stat().st_mtime >= since]
+        if not matching_files:
+            return False, matched_files, f"Missing expected files for content check: {file_pattern}"
+
+        for file_path in matching_files:
+            matched_files.append(file_path)
+            content = file_path.read_text(encoding="utf-8")
+            for content_pattern in content_patterns:
+                if re.search(content_pattern, content, re.MULTILINE | re.DOTALL):
+                    return (
+                        False,
+                        matched_files,
+                        f"Unexpected content pattern {content_pattern!r} in {file_path}",
+                    )
+
+    return True, matched_files, ""
+
+
 def validate_output(
     output: str, expected_patterns: list[str], not_expected_patterns: list[str]
 ) -> tuple[bool, str]:
@@ -337,6 +416,13 @@ def create_test_config(config_dir: Path, content: str):
     config_file = config_dir / "config.toml"
     config_file.write_text(content)
     return config_file
+
+
+def create_test_input_file(config_dir: Path):
+    """Create a test input file for --input-file cases."""
+    input_file = config_dir / "input.md"
+    input_file.write_text("background input file content\n")
+    return input_file
 
 
 def find_latest_output_file(pattern: str = "*_*_*_*_*.md") -> Path | None:
@@ -435,6 +521,11 @@ def _prepare_test_isolation(
     # (and break T-SIG-01's 1.5s SIGINT timing). Keep uv on the shared cache.
     env.setdefault("UV_CACHE_DIR", str(Path.home() / ".cache" / "uv"))
     return tmpdir, cmd, env, output_base
+
+
+def _expand_tmpdir_placeholders(cmd: list[str], tmpdir: Path) -> list[str]:
+    """Expand {tmpdir} placeholders after per-test isolation is allocated."""
+    return [arg.replace("{tmpdir}", str(tmpdir)) for arg in cmd]
 
 
 def _resolve_output_target(cmd: list[str]) -> tuple[Path | None, str | None]:
@@ -699,6 +790,7 @@ class InteractiveTestRunner:
         # Set up environment
         test_env = os.environ.copy()
         test_env["COLUMNS"] = "80"  # Standard terminal width
+        test_env.setdefault("UV_CACHE_DIR", str(Path.home() / ".cache" / "uv"))
 
         # Add test-specific environment variables
         if test_case.env:
@@ -1304,6 +1396,8 @@ api_key = "{api_key}"
 """
                 config_path.write_text(config_content)
 
+        test_command = _expand_tmpdir_placeholders(test_command, tmpdir)
+
         # Create test prompt file if needed
         if "--prompt-file" in test_command:
             idx = test_command.index("--prompt-file")
@@ -1430,6 +1524,46 @@ api_key = "{api_key}"
                 if not passed:
                     result.passed = False
                     result.error_message = f"File validation failed: {error}"
+                    return result
+
+            if test_case.not_expected_files:
+                passed, unexpected_files, error = validate_file_absence(
+                    test_case.not_expected_files,
+                    since=start_time,
+                    base=output_base if output_base is not None else Path("."),
+                )
+                result.created_files.extend(unexpected_files)
+                if not passed:
+                    result.passed = False
+                    result.error_message = f"File absence validation failed: {error}"
+                    return result
+
+            if test_case.expected_file_content_patterns:
+                passed, matched_files, error = validate_file_contents(
+                    test_case.expected_file_content_patterns,
+                    since=start_time,
+                    base=output_base if output_base is not None else Path("."),
+                )
+                result.created_files.extend(
+                    p for p in matched_files if p not in result.created_files
+                )
+                if not passed:
+                    result.passed = False
+                    result.error_message = f"File content validation failed: {error}"
+                    return result
+
+            if test_case.not_expected_file_content_patterns:
+                passed, matched_files, error = validate_file_content_absence(
+                    test_case.not_expected_file_content_patterns,
+                    since=start_time,
+                    base=output_base if output_base is not None else Path("."),
+                )
+                result.created_files.extend(
+                    p for p in matched_files if p not in result.created_files
+                )
+                if not passed:
+                    result.passed = False
+                    result.error_message = f"File content absence validation failed: {error}"
                     return result
         finally:
             # Always run teardown function if provided
@@ -1725,6 +1859,16 @@ api_key = "{api_key}"
 # Test Definitions
 # ============================================================================
 
+
+def mock_stream_patterns(prompt: str, mode: str = "default") -> list[str]:
+    """Expected stdout contract for immediate-mode mock streaming."""
+    return [
+        rf"# Mock streaming response \(mode={re.escape(mode)}\)",
+        rf"Echo: {re.escape(prompt)}",
+        r"Done\.",
+    ]
+
+
 # All test cases
 all_tests = [
     # Basic CLI Tests (No Provider Required)
@@ -1737,11 +1881,10 @@ all_tests = [
     ),
     TestCase(
         test_id="M1T-02",
-        description="Quick mode with mock provider creates output file",
+        description="Quick mode with mock provider streams without default result file",
         command=[THOTH_EXECUTABLE, "test prompt", "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
-        expected_files=["*_*_*_mock_*.md"],
-        cleanup_files=["*_*_*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test prompt"),
+        not_expected_files=["*_*_*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1749,10 +1892,21 @@ all_tests = [
     TestCase(
         test_id="M1T-03",
         description="Filename follows correct pattern",
-        command=[THOTH_EXECUTABLE, "test filename pattern", "--provider", "mock"],
-        expected_stdout_patterns=[r"\d{4}-\d{2}-\d{2}_\d{6}_\w+_mock_[\w-]+\.md"],
-        expected_files=["????-??-??_??????_*_mock_*.md"],
-        cleanup_files=["*_*_*_mock_*.md"],
+        command=[
+            THOTH_EXECUTABLE,
+            "test filename pattern",
+            "--provider",
+            "mock",
+            "--project",
+            "filename_pattern_test",
+        ],
+        expected_stdout_patterns=mock_stream_patterns("test filename pattern") + [r"Saved to:"],
+        expected_files=["research-outputs/filename_pattern_test/????-??-??_??????_*_mock_*.md"],
+        cleanup_files=[
+            "research-outputs/filename_pattern_test/*",
+            "research-outputs/filename_pattern_test",
+            "research-outputs",
+        ],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1780,9 +1934,8 @@ all_tests = [
         test_id="MOCK-01",
         description="Mock provider works with environment API key",
         command=[THOTH_EXECUTABLE, "test env key", "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test env key"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1798,9 +1951,8 @@ all_tests = [
             "--api-key-mock",
             "dummy-key",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test cli key"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="cli",
@@ -1810,9 +1962,8 @@ all_tests = [
         test_id="T-CLI-03",
         description="Short form -P works for provider flag",
         command=[THOTH_EXECUTABLE, "test short provider flag", "-P", "mock"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test short provider flag"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1866,9 +2017,9 @@ all_tests = [
             "--config",
             "./test_config.toml",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md", "test_config.toml"],
+        expected_stdout_patterns=mock_stream_patterns("test custom config"),
+        not_expected_files=["*_mock_*.md"],
+        cleanup_files=["test_config.toml"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="config",
@@ -1878,9 +2029,8 @@ all_tests = [
         test_id="M3T-01",
         description="Mock provider completes successfully",
         command=[THOTH_EXECUTABLE, "test mock", "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test mock"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1904,6 +2054,205 @@ all_tests = [
         api_key_method="env",
     ),
     TestCase(
+        test_id="BG-01",
+        description="Background mode works with command-line mock API key",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background cli key",
+            "--provider",
+            "mock",
+            "--api-key-mock",
+            "dummy-key",
+        ],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: background cli key", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="cli",
+    ),
+    TestCase(
+        test_id="BG-02",
+        description="Background mode works with custom config file",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background config",
+            "--provider",
+            "mock",
+            "--config",
+            "./test_config.toml",
+        ],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: background config", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md", "test_config.toml"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="config",
+    ),
+    TestCase(
+        test_id="BG-03",
+        description="Background mode reads prompt from file",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "--prompt-file",
+            "test_prompt.txt",
+            "--provider",
+            "mock",
+        ],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: test prompt from file", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md", "test_prompt.txt"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-04",
+        description="Background mode reads prompt from stdin",
+        command=[THOTH_EXECUTABLE, "deep_research", "--prompt-file", "-", "--provider", "mock"],
+        stdin_input="background prompt from stdin\n",
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: background prompt from stdin", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-05",
+        description="Background mode supports short -P provider flag",
+        command=[THOTH_EXECUTABLE, "deep_research", "background short provider", "-P", "mock"],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: background short provider", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-06",
+        description="Background mode writes project outputs under --project",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background project",
+            "--provider",
+            "mock",
+            "--project",
+            "background-project-bg06",
+        ],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["research-outputs/background-project-bg06/*_mock_*.md"],
+        expected_file_content_patterns={
+            "research-outputs/background-project-bg06/*_mock_*.md": [
+                r"Prompt: background project",
+                r"Mode: deep_research",
+            ]
+        },
+        cleanup_files=[
+            "research-outputs/background-project-bg06/*",
+            "research-outputs/background-project-bg06",
+        ],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-07",
+        description="Background mode records --input-file in output metadata",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background input file",
+            "--provider",
+            "mock",
+            "--input-file",
+            "{tmpdir}/input.md",
+        ],
+        setup_func=create_test_input_file,
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [
+                r"Prompt: background input file",
+                r"Mode: deep_research",
+                r"input_files:",
+                r"input\.md",
+            ]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-08",
+        description="Background mode honors --no-metadata in output files",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background no metadata",
+            "--provider",
+            "mock",
+            "--no-metadata",
+        ],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [
+                r"# Mock Research Results",
+                r"## Prompt: background no metadata",
+            ]
+        },
+        not_expected_file_content_patterns={
+            "*_mock_*.md": [r"^---$", r"operation_id:", r"### Prompt"]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="BG-09",
+        description="Background mode honors --quiet while still writing output",
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "background quiet",
+            "--provider",
+            "mock",
+            "--quiet",
+        ],
+        expected_stdout_patterns=[r"_mock_background-quiet\.md"],
+        not_expected_stdout_patterns=[r"Research completed", r"Results saved to:", r"Progress:"],
+        expected_files=["*_mock_*.md"],
+        expected_file_content_patterns={
+            "*_mock_*.md": [r"Prompt: background quiet", r"Mode: deep_research"]
+        },
+        cleanup_files=["*_mock_*.md"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
         test_id="M3T-03",
         description="Invalid provider shows error",
         command=[THOTH_EXECUTABLE, "test", "--provider", "invalid-provider"],
@@ -1917,10 +2266,9 @@ all_tests = [
         test_id="M4T-01",
         description="Default mode is 'default' not 'deep_research'",
         command=[THOTH_EXECUTABLE, "test default mode", "--provider", "mock", "-v"],
-        expected_stdout_patterns=[r"Operation ID:"],
-        expected_files=["*_default_*.md"],
+        expected_stdout_patterns=[r"Operation ID:", *mock_stream_patterns("test default mode")],
+        not_expected_files=["*_default_*.md"],
         not_expected_stdout_patterns=[r"Mode: deep_research"],
-        cleanup_files=["*_default_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1935,9 +2283,8 @@ all_tests = [
             "--provider",
             "mock",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_thinking_*.md"],
-        cleanup_files=["*_thinking_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test thinking mode", mode="thinking"),
+        not_expected_files=["*_thinking_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -1959,9 +2306,8 @@ all_tests = [
             "--provider",
             "mock",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_clarification_*.md"],
-        cleanup_files=["*_clarification_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test clarification", mode="clarification"),
+        not_expected_files=["*_clarification_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2051,11 +2397,11 @@ all_tests = [
         test_id="M5T-10b",
         description="Synchronous operation transitions queued→running→completed",
         command=[THOTH_EXECUTABLE, "test lifecycle sync", "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed|Results saved"],
+        expected_stdout_patterns=mock_stream_patterns("test lifecycle sync"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
-        cleanup_files=["*_mock_*.md"],
     ),
     TestCase(
         test_id="M5T-10c",
@@ -2093,11 +2439,23 @@ all_tests = [
     # Milestone 6: Output Management
     TestCase(
         test_id="M6T-01",
-        description="Files created in current directory by default",
-        command=[THOTH_EXECUTABLE, "test output", "--provider", "mock"],
-        expected_stdout_patterns=[r"Results saved to:"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        description="Explicit --out writes immediate stream to a file",
+        command=[
+            THOTH_EXECUTABLE,
+            "ask",
+            "test output",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--out",
+            "{tmpdir}/stream-output.md",
+        ],
+        not_expected_stdout_patterns=[r"# Mock streaming response"],
+        expected_files=["stream-output.md"],
+        expected_file_content_patterns={
+            "stream-output.md": mock_stream_patterns("test output", mode="thinking")
+        },
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2107,15 +2465,79 @@ all_tests = [
         description="Output directory can be specified",
         command=[
             THOTH_EXECUTABLE,
+            "deep_research",
             "test output dir",
             "--provider",
             "mock",
             "-o",
             "test_output",
         ],
-        expected_stdout_patterns=[r"Results saved to:"],
+        expected_stdout_patterns=[r"Research completed", r"Results saved to:"],
         expected_files=["test_output/*_mock_*.md"],
+        expected_file_content_patterns={
+            "test_output/*_mock_*.md": [
+                r"Prompt: test output dir",
+                r"Mode: deep_research",
+                r"mock research result",
+            ]
+        },
         cleanup_files=["test_output/*", "test_output"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="M6T-03",
+        description="Immediate --output-dir alone does not create a result file",
+        command=[
+            THOTH_EXECUTABLE,
+            "test output dir immediate",
+            "--provider",
+            "mock",
+            "-o",
+            "immediate_output",
+        ],
+        expected_stdout_patterns=mock_stream_patterns("test output dir immediate"),
+        not_expected_files=["immediate_output/*_mock_*.md"],
+        cleanup_files=["immediate_output"],
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="M6T-04",
+        description="Bare prompt leading --out writes immediate stream to a file",
+        command=[
+            THOTH_EXECUTABLE,
+            "--out",
+            "{tmpdir}/bare-output.md",
+            "--provider",
+            "mock",
+            "bare output",
+        ],
+        not_expected_stdout_patterns=[r"# Mock streaming response"],
+        expected_files=["bare-output.md"],
+        expected_file_content_patterns={"bare-output.md": mock_stream_patterns("bare output")},
+        expected_exit_code=0,
+        provider="mock",
+        api_key_method="env",
+    ),
+    TestCase(
+        test_id="M6T-05",
+        description="Bare prompt trailing --out writes immediate stream to a file",
+        command=[
+            THOTH_EXECUTABLE,
+            "bare trailing output",
+            "--provider",
+            "mock",
+            "--out",
+            "{tmpdir}/bare-trailing-output.md",
+        ],
+        not_expected_stdout_patterns=[r"# Mock streaming response"],
+        expected_files=["bare-trailing-output.md"],
+        expected_file_content_patterns={
+            "bare-trailing-output.md": mock_stream_patterns("bare trailing output")
+        },
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2125,9 +2547,8 @@ all_tests = [
         test_id="M7T-02",
         description="Verbose mode shows detailed info",
         command=[THOTH_EXECUTABLE, "test verbose", "--provider", "mock", "-v"],
-        expected_stdout_patterns=[r"Operation ID:"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=[r"Operation ID:", *mock_stream_patterns("test verbose")],
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2169,9 +2590,8 @@ all_tests = [
         test_id="EDGE-02",
         description="Very long prompt is handled",
         command=[THOTH_EXECUTABLE, "a" * 1000, "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("a" * 1000),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2197,10 +2617,9 @@ all_tests = [
         test_id="COMB-02",
         description="No combined report without --combined flag",
         command=[THOTH_EXECUTABLE, "test no combined", "--provider", "mock"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test no combined"),
         not_expected_stdout_patterns=[r"_combined_"],
-        cleanup_files=["*_mock_*.md"],
+        not_expected_files=["*_mock_*.md", "*_combined_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2216,9 +2635,9 @@ all_tests = [
             "--provider",
             "mock",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md", "test_prompt.txt"],
+        expected_stdout_patterns=mock_stream_patterns("test prompt from file"),
+        not_expected_files=["*_mock_*.md"],
+        cleanup_files=["test_prompt.txt"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2228,9 +2647,8 @@ all_tests = [
         description="Read prompt from stdin",
         command=[THOTH_EXECUTABLE, "--prompt-file", "-", "--provider", "mock"],
         stdin_input="test prompt from stdin\n",
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        expected_stdout_patterns=mock_stream_patterns("test prompt from stdin"),
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2247,9 +2665,9 @@ all_tests = [
             "--provider",
             "mock",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md", "custom_config.toml"],
+        expected_stdout_patterns=mock_stream_patterns("test config"),
+        not_expected_files=["*_mock_*.md"],
+        cleanup_files=["custom_config.toml"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2259,9 +2677,9 @@ all_tests = [
         test_id="QUIET-01",
         description="Quiet mode suppresses output",
         command=[THOTH_EXECUTABLE, "test quiet", "--quiet", "--provider", "mock"],
+        expected_stdout_patterns=mock_stream_patterns("test quiet"),
         not_expected_stdout_patterns=[r"Progress:", r"Researching:"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2270,9 +2688,9 @@ all_tests = [
         test_id="QUIET-02",
         description="Quiet mode short form -Q",
         command=[THOTH_EXECUTABLE, "test quiet short", "-Q", "--provider", "mock"],
+        expected_stdout_patterns=mock_stream_patterns("test quiet short"),
         not_expected_stdout_patterns=[r"Progress:", r"Researching:"],
-        expected_files=["*_mock_*.md"],
-        cleanup_files=["*_mock_*.md"],
+        not_expected_files=["*_mock_*.md"],
         expected_exit_code=0,
         provider="mock",
         api_key_method="env",
@@ -2289,7 +2707,7 @@ all_tests = [
             "--provider",
             "mock",
         ],
-        expected_stdout_patterns=[r"Research completed"],
+        expected_stdout_patterns=mock_stream_patterns("test project") + [r"Saved to:"],
         expected_files=["research-outputs/test_project/*_mock_*.md"],
         cleanup_files=[
             "research-outputs/test_project/*",
@@ -2328,9 +2746,8 @@ all_tests = [
         test_id="REAL-01",
         description="OpenAI provider with real API key",
         command=[THOTH_EXECUTABLE, "test openai", "--provider", "openai"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_openai_*.md"],
-        cleanup_files=["*_openai_*.md"],
+        expected_stdout_patterns=[r".+"],
+        not_expected_files=["*_openai_*.md"],
         expected_exit_code=0,
         provider="openai",
         api_key_method="env",
@@ -2350,7 +2767,13 @@ all_tests = [
     TestCase(
         test_id="T-SIG-01",
         description="Graceful exit on Ctrl-C with checkpoint save",
-        command=[THOTH_EXECUTABLE, "test interrupt handling", "--provider", "mock"],
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "test interrupt handling",
+            "--provider",
+            "mock",
+        ],
         expected_stdout_patterns=[
             r"Interrupt received\. Saving checkpoint",
             r"Checkpoint saved\. Resume with: thoth resume",
@@ -2368,7 +2791,7 @@ all_tests = [
     TestCase(
         test_id="TR-01",
         description="Transient errors below threshold are retried and job completes",
-        command=[THOTH_EXECUTABLE, "transient retry", "--provider", "mock"],
+        command=[THOTH_EXECUTABLE, "deep_research", "transient retry", "--provider", "mock"],
         env={
             "THOTH_MOCK_BEHAVIOR": "flake:2",
             "THOTH_POLL_INTERVAL": "0.1",
@@ -2391,7 +2814,7 @@ all_tests = [
     TestCase(
         test_id="TR-02",
         description="Transient errors above threshold fail with recoverable status and resume hint",
-        command=[THOTH_EXECUTABLE, "transient exhaust", "--provider", "mock"],
+        command=[THOTH_EXECUTABLE, "deep_research", "transient exhaust", "--provider", "mock"],
         env={
             "THOTH_MOCK_BEHAVIOR": "flake:10",
             "THOTH_POLL_INTERVAL": "0.1",
@@ -2420,6 +2843,29 @@ all_tests = [
             r"Mock permanent failure",
         ],
         not_expected_stdout_patterns=[
+            r"This failure is recoverable",
+            r"Resume with: .*thoth resume",
+            r"Research completed",
+        ],
+        expected_exit_code=1,
+        provider="mock",
+        api_key_method="env",
+        cleanup_files=["*_mock_*.md"],
+    ),
+    TestCase(
+        test_id="TR-04",
+        description="Immediate transient-like stream failure is permanent and non-resumable",
+        command=[THOTH_EXECUTABLE, "immediate flake fail", "--provider", "mock"],
+        env={
+            "THOTH_MOCK_BEHAVIOR": "flake:2",
+            "THOTH_POLL_INTERVAL": "0.1",
+        },
+        expected_stdout_patterns=[
+            r"permanent failure",
+            r"Mock streaming failure \(behavior=flake:2\)",
+        ],
+        not_expected_stdout_patterns=[
+            r"transient error",
             r"This failure is recoverable",
             r"Resume with: .*thoth resume",
             r"Research completed",
@@ -2901,7 +3347,7 @@ all_tests = [
         test_id="M8T-01",
         description="OpenAI provider initialization with API key",
         command=[THOTH_EXECUTABLE, "test openai init", "--provider", "openai", "-v"],
-        expected_stdout_patterns=[r"openai API Key: .*\.\.\.", r"Research completed"],
+        expected_stdout_patterns=[r"openai API Key: .*\.\.\.", r".+"],
         expected_exit_code=0,
         provider="openai",
         api_key_method="env",
@@ -2964,11 +3410,21 @@ all_tests = [
     ),
     TestCase(
         test_id="M8T-06",
-        description="OpenAI provider creates output file",
-        command=[THOTH_EXECUTABLE, "test output", "--provider", "openai"],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_openai_*.md"],
-        cleanup_files=["*_openai_*.md"],
+        description="OpenAI provider writes explicit --out file",
+        command=[
+            THOTH_EXECUTABLE,
+            "ask",
+            "test output",
+            "--mode",
+            "thinking",
+            "--provider",
+            "openai",
+            "--out",
+            "{tmpdir}/openai-output.md",
+        ],
+        not_expected_stdout_patterns=[r".+"],
+        expected_files=["openai-output.md"],
+        expected_file_content_patterns={"openai-output.md": [r".+"]},
         expected_exit_code=0,
         provider="openai",
         api_key_method="env",
@@ -2977,7 +3433,7 @@ all_tests = [
         test_id="M8T-07",
         description="OpenAI provider with verbose shows configuration",
         command=[THOTH_EXECUTABLE, "test verbose", "--provider", "openai", "-v"],
-        expected_stdout_patterns=[r"openai API Key: .*\.\.\.", r"Research completed"],
+        expected_stdout_patterns=[r"openai API Key: .*\.\.\.", r".+"],
         expected_exit_code=0,
         provider="openai",
         api_key_method="env",
@@ -2988,7 +3444,7 @@ all_tests = [
         description="OpenAI provider handles rate limit gracefully",
         command=[THOTH_EXECUTABLE, "test rate limit", "--provider", "openai"],
         # This test expects normal completion (rate limits are retried)
-        expected_stdout_patterns=[r"Research completed|Rate limit"],
+        expected_stdout_patterns=[r".+|Rate limit"],
         expected_exit_code=0,
         provider="openai",
         api_key_method="env",
@@ -3005,9 +3461,9 @@ all_tests = [
             "--config",
             "./test_config.toml",
         ],
-        expected_stdout_patterns=[r"Research completed"],
-        expected_files=["*_openai_*.md"],
-        cleanup_files=["*_openai_*.md", "test_config.toml"],
+        expected_stdout_patterns=[r".+"],
+        not_expected_files=["*_openai_*.md"],
+        cleanup_files=["test_config.toml"],
         expected_exit_code=0,
         provider="openai",
         api_key_method="config",
@@ -3035,7 +3491,13 @@ all_tests = [
     TestCase(
         test_id="BUG03-03",
         description="polling loop: mock provider research completes correctly with fixed poll loop",
-        command=[THOTH_EXECUTABLE, "test poll fix regression", "--provider", "mock"],
+        command=[
+            THOTH_EXECUTABLE,
+            "deep_research",
+            "test poll fix regression",
+            "--provider",
+            "mock",
+        ],
         env={"THOTH_POLL_INTERVAL": "2"},
         expected_stdout_patterns=[r"(?i)research completed|output saved"],
         cleanup_files=["*_mock_*.md"],


### PR DESCRIPTION
## Summary

Implements **P18** — promotes the immediate-vs-background distinction to a first-class declared `kind` field on every research mode, splits execution into a streaming immediate path and a polling background path, surfaces mode/model mismatches at runtime before any HTTP, adds `--out`/`--append` for immediate output sinks, ships `thoth cancel <op-id>`, wires the dead-code `--kind` filter on `thoth modes`, and renames `mini_research → quick_research` with a deprecation alias.

Targets release-please-tagged **v3.1.0** (next minor on the v3 line). Ten phases, ~16 commits across the series, 627 default tests pass + 3 extended deselected. Spec: `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md`.

## What ships

### Mode contract (Phase A)
- Every builtin in `BUILTIN_MODES` declares `kind: "immediate" | "background"`
- `models.KNOWN_MODELS` derived from builtins; cross-mode kind conflicts raise at import
- New `config.mode_kind(cfg)` resolver replaces `is_background_mode` for resolution-path callers; `is_background_mode` survives as a thin compat wrapper (removed in v4.0.0)
- 4 call sites migrated to `mode_kind`; 5 model-level callers (provider taxonomy + spinner gate) keep `is_background_model`
- Audit trail: `planning/p18-call-site-audit.md`

### Runtime mismatch (Phase B)
- New `errors.ModeKindMismatchError` with `mode_name`/`model`/`declared_kind`/`required_kind`
- `OpenAIProvider.submit()` calls `_validate_kind_for_model(mode)` first thing — raises **before any HTTP** when declared `immediate` but model needs `background`
- Reverse case (declared `background` + regular model) is legal force-background, not checked
- `create_provider` threads `mode_config["kind"]` into `provider_config`

### Path split + UX gates (Phase C)
- `should_show_spinner` and `_poll_display` accept `mode_cfg`; immediate runs see neither spinner nor Progress bar
- 4 `thoth resume` / `Operation ID` / `thoth status` hint sites in `run.py` gated on `mode_kind == "background"`
- `--pick-model` error wording references declared `kind` instead of substring heuristic

### Mode rename + `--kind` filter (Phase D)
- `mini_research → quick_research` (alias kept; emits `DeprecationWarning` on use; removed in v4.0.0)
- `thoth modes --kind <immediate|background>` filter wired via the dead-code `mode_kind` completer in `completion/sources.py:79` (PR3 left it as forward-compat)

### Streaming + output sinks (Phase E)
- New `providers/base.py:StreamEvent` dataclass + `provider.stream()` contract
- `MockProvider.stream()` yields deterministic chunks for hermetic tests
- `OpenAIProvider.stream()` uses `client.responses.stream(...)` for non-deep-research models
- New `src/thoth/sinks.py` — `MultiSink` fans `write(chunk)` to a list of stdout/file handles, lazy file open, idempotent close
- `--out PATH` (repeatable, `-` for stdout, comma-list accepted) and `--append` flags added to `_RESEARCH_OPTIONS`
- New `_execute_immediate(...)` in `run.py` — calls `provider.stream()`, sinks chunks, falls back to `submit + get_result` if a provider raises `NotImplementedError`
- Bare-prompt path (`thoth --out FILE "topic"`) and `thoth ask --out FILE` both wired end-to-end (a partial-wiring gap from the initial Phase E commit was caught and fixed)

### Cancel (Phases F + G)
- Per-provider research findings: `planning/p18-cancel-research.md`
- `provider.cancel()` contract on base; OpenAI implementation via `client.responses.cancel`; Mock implementation; Perplexity inherits `NotImplementedError`
- New `thoth cancel <op-id>` Click subcommand mirroring `resume.py` pattern
- `commands.cancel_operation()` orchestrator: catches `NotImplementedError` and reports best-effort, updates checkpoint to cancelled regardless

### User-mode warning (Phase H)
- `_validate_user_modes_kind()` warns once at config load when a `[modes.X]` table omits `kind` (v4.0.0 will error per the future P19 entry referenced inside P18)

### Extended test infrastructure (Phase I)
- `pyproject.toml` registers `extended` pytest marker + `addopts = "-m 'not extended'"` so default runs deselect
- New `tests/extended/test_model_kind_runtime.py` parametrized over `KNOWN_MODELS`, real API; cancels background submissions to limit cost
- `just test-extended` recipe + `.github/workflows/extended.yml` nightly cron (gated on `OPENAI_API_KEY` repo secret)

### Polish + cleanup (Phase J + follow-up commits)
- `HelpFirstUsageError` — usage errors now render the leaf subcommand's help block BEFORE the error line
- `run_research`'s outer `except Exception` no longer re-transitions ops already marked failed (double-fail guard)
- `OperationStatus(...)` constructor records `input_files` so `--input-file` / `--auto` chains persist
- `thoth_test` integration runner gains `not_expected_files`, `expected_file_content_patterns`, `not_expected_file_content_patterns` fields and matching validators (covers the streaming contract end-to-end)
- `tests/conftest_p16.py:run_thoth` now isolates `HOME` per subprocess invocation; fixes pre-existing env-flaky parity-baseline drift
- `commitlint.config.mjs` becomes self-contained (no `extends:` on `@commitlint/config-conventional`); `package.json` removed; future worktrees no longer need `npm install` to commit

### New future-work entry
- `PROJECTS.md` gains `P20: Extended Real-API Workflow Coverage — Mirror Mock Contracts` with 27 task slots covering immediate/background workflow parity testing against the live OpenAI API

## Test plan

### Default suite (no API key required)
- [x] `uv run pytest tests/ -q` — **627 pass, 3 extended deselected, 16 deprecation warnings** (intentional migration signals from `mini_research` alias and user-mode kind warnings)
- [x] `just check` — ruff lint + ruff format + ty all clean
- [x] `./thoth_test -r --provider mock` — 76 pass, 1 skipped (lefthook ran the full integration suite as part of every commit's pre-commit hook)
- [x] `bandit -ll src/thoth/` — no issues (one Medium-Low false positive on `errors.py:125` suppressed with rationale)
- [x] `gitleaks` — clean

### Manual smoke (mock provider, no network)
```bash
# Streaming immediate
MOCK_API_KEY=test thoth ask "streaming-test" --mode thinking --provider mock

# --out file
MOCK_API_KEY=test thoth ask "test" --mode thinking --provider mock --out /tmp/p18.md && cat /tmp/p18.md

# tee
MOCK_API_KEY=test thoth ask "tee" --mode thinking --provider mock --out -,/tmp/tee.md

# bare-prompt --out (leading and trailing forms)
MOCK_API_KEY=test thoth --out /tmp/lead.md --provider mock "leading prompt"
MOCK_API_KEY=test thoth "trailing prompt" --provider mock --out /tmp/trail.md

# --kind filter
thoth modes --kind immediate
thoth modes --kind background

# Cancel a missing op (exit 6)
thoth cancel MISSING-ID || echo "exit $?"

# mini_research deprecation alias
MOCK_API_KEY=test thoth ask "alias" --mode mini_research --provider mock 2>&1 | head -5
```

### Manual smoke (real OpenAI, requires API key)
```bash
# Streaming immediate against real o3
OPENAI_API_KEY=sk-... thoth ask "What is the difference between a vector and a covector? Two sentences."

# Misconfigured mode (no HTTP fires)
mkdir -p /tmp/p18-bad-config && cat > /tmp/p18-bad-config/thoth.toml <<'TOML'
version = "2.0"
[modes.bad_thinking]
provider = "openai"
model = "o3-deep-research"
kind = "immediate"
TOML
thoth --config /tmp/p18-bad-config/thoth.toml ask "anything" --mode bad_thinking

# Live cancel — submit then cancel a real background op
thoth ask "to be cancelled" --mode deep_research --async
thoth cancel <op-id-from-above>
```

### Extended contract suite (~$0.10, ~30s)
- [ ] `OPENAI_API_KEY=sk-... just test-extended` — 3 contract tests pass against real OpenAI

## Coordination notes

- Built on top of merged `1f8efe9 docs(p18): reevaluate spec, plan, and PROJECTS.md against post-P16-PR3 codebase` — the spec/plan in this PR reflect the v3.1.0 target.
- No PR2/PR3 changes required: P18 plugs into the structures shipped in `f8b62f2` (`cli_subcommands/`, `_research_options`, `--json` envelope, `progress.py`, `completion/sources.py:79 mode_kind`).
- A future **P19** (`v4.0.0`) will hard-error on user modes missing `kind` and remove the `mini_research`/`async` deprecation aliases. Tracked in P18's `**Follow-up tracked separately**` block.
- A future **P20** (`tests/extended/test_real_api_workflows.py`) will mirror the mock workflow contracts at the real-API workflow boundary. Drafted as a full project entry at the top of `PROJECTS.md` with 27 task slots.

## Backwards compatibility

- All v3.x users see no breakage: legacy `is_background_mode(cfg)` still works; the `async: bool` mode-config field still works (with a `DeprecationWarning`); user modes missing `kind` still resolve via substring fallback (with a `DeprecationWarning`).
- New surface (`--out`, `--append`, `thoth cancel`, `--kind` filter, `quick_research` mode) is purely additive.

## Files changed

47 files; ~3500 line delta. See commit history on the branch — 16 themed commits with conventional-commit prefixes that release-please will pick up for the v3.1.0 changelog.

## Spec & plan

- `docs/superpowers/specs/2026-04-26-p18-immediate-vs-background-design.md`
- `docs/superpowers/plans/2026-04-26-p18-immediate-vs-background.md`
- `planning/p18-cancel-research.md`
- `planning/p18-call-site-audit.md`