### PR TITLE
feat(p21): configuration profile resolution & overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,16 @@ After making any code changes, follow this verification workflow:
 
 This ensures both the main executable and test suite maintain code quality standards.
 
+### Periodic full-gate runs (don't save it all for the end)
+
+When working through a multi-commit task, do not save the full pre-commit gate for the very last commit. Run it periodically:
+
+- **Complex / wide-blast-radius commit**: run the full gate immediately after, before starting the next commit.
+- **Simple commits** (test additions, docs, small fixes): batch at most 2–3 commits between full-gate runs.
+- **Always**: the last commit before `git push` MUST go through the full hook set.
+
+⚠️ `just check` does NOT include `ruff format --check`. If you bypass lefthook with `LEFTHOOK=0`, also run `uv run ruff format --check src/ tests/` (or `ruff format`) yourself — CI runs the format-check separately and will fail otherwise. See `CLAUDE.md` "Fast Iteration Loop" → "Periodic full-gate runs" for full guidance.
+
 ### Test Debugging Workflow
 - When a test fails, start by running the test suite with only the failing tests
 - Fix the specific tests while running the subset of tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,43 @@ Two consecutive failures of the same test = real bug. One failure = noise.
   often; keep changes uncommitted and run targeted tools until green.
 - **Exception**: for a short-lived intermediate WIP commit you plan to
   squash, `LEFTHOOK=0` is acceptable IF you have already run the equivalent
-  checks manually (`just check` + the targeted tests you care about). The
-  **last commit before `git push`** MUST go through the full hook set.
+  checks manually (`just check` + `uv run ruff format --check src/ tests/`
+  + the targeted tests you care about). The **last commit before
+  `git push`** MUST go through the full hook set.
+- ⚠️ `just check` does NOT run `ruff format --check`. If you bypass
+  lefthook, you must also run `ruff format --check` (or `ruff format`)
+  yourself, otherwise CI's format gate will catch it.
+
+### Periodic full-gate runs (don't save it all for the end)
+
+When working through a multi-commit task, do **not** save the full
+lefthook-equivalent gate for the very last commit. Run it periodically
+as you go, scaled to commit complexity:
+
+- **Complex / wide-blast-radius commit** (touches many files, refactors
+  core modules, changes runtime behavior, modifies CLI surface): run
+  the full gate **immediately** after that commit, before starting
+  the next one.
+- **Simple commits** (test additions, doc tweaks, small bug fixes):
+  batch at most **2–3 commits** between full-gate runs. Never more
+  than "a few."
+- **Always**: the last commit before `git push` goes through the
+  full hook set (see above).
+
+The goal is to catch latent format / lint / type / test errors while
+the working set is still small enough to fix cheaply, instead of
+letting them compound until CI fails after push. Concretely, run:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run ty check src/
+uv run pytest -q
+./thoth_test -r --skip-interactive -q
+```
+
+…or equivalently, do a normal `git commit` (no `LEFTHOOK=0`) which
+runs all of the above via lefthook.
 
 ## Code Quality Assurance Workflow (final pre-commit gate)
 

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -182,6 +182,68 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 
 ---
 
+## [ ] Project P21c: Config Filename Standardization
+**Goal**: Standardize Thoth's config filename to `thoth.config.toml` so the filename alone uniquely identifies a Thoth config file. Three canonical locations: one user-tier (`$XDG_CONFIG_HOME/thoth/thoth.config.toml`) and two project-tier (`./thoth.config.toml` or `./.thoth.config.toml`, mutually exclusive). Clean break — legacy filenames (`config.toml` in user dir, `thoth.toml`, `.thoth/config.toml`) are no longer read; their presence is detected only to enrich "config not found" error messages with rename guidance.
+
+**References**
+- **Spec:** `docs/superpowers/specs/2026-04-28-p21c-config-filename-standardization-design.md`
+- **Plan:** `docs/superpowers/plans/2026-04-28-p21c-config-filename-standardization.md`
+- **Related:** P21 (`docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`), P21b (`docs/superpowers/specs/2026-04-28-p21b-configuration-profiles-crud-design.md`) — both reference legacy filenames in their specs/plans/tests; P21c either lands first or sweeps through them.
+
+**Status**: Spec + plan drafted; decisions locked (filename, no-legacy clean break, error on project-root ambiguity, `init --user` in scope, `--hidden` flag spelling, `--force` applies to `--user`). Awaiting greenlight to begin implementation (Task 1 = failing test scenario matrix).
+
+**Scope**
+- Canonical filename is `thoth.config.toml`. Three accepted locations:
+  - User: `$XDG_CONFIG_HOME/thoth/thoth.config.toml`
+  - Project root, visible: `./thoth.config.toml`
+  - Project root, dotfile: `./.thoth.config.toml`
+- The two project-tier filenames are mutually exclusive. Both present → `ConfigAmbiguousError` with a "delete one before continuing" message. No precedence is applied.
+- Legacy filenames (`config.toml` in user XDG dir, `./thoth.toml`, `./.thoth/config.toml`) are **not loaded**. The `.thoth/` directory form is retired for config purposes.
+- A "config not found" error path (and only that path) checks for legacy files at the legacy paths and, if any are present, names them in the suggestion text with the rename target. The legacy-detection helper is never called on the happy path.
+- `thoth init` writes `./thoth.config.toml` by default. A flag (`--hidden` or similar — final spelling decided in plan) writes `./.thoth.config.toml` instead. `thoth init --user` writes `$XDG_CONFIG_HOME/thoth/thoth.config.toml`. `--user` and the dotfile flag are mutually exclusive. `--force` semantics unchanged.
+- Sweep README, `manual_testing_instructions.md`, help text, error messages, and the P21/P21b spec/plan docs to use the canonical filename.
+
+**Out of Scope**
+- A `thoth config migrate` CLI command that renames files in place.
+- Any deprecation-window or fallback read of legacy filenames. Legacy reads are gone, full stop.
+- Changes to file format, file structure, or the `[profiles.<name>]` overlay semantics.
+- A `THOTH_CONFIG_FILENAME` env var to override the filename.
+- Project marker semantics — presence of either canonical project path still means "this is a Thoth project."
+- Picking precedence between `./thoth.config.toml` and `./.thoth.config.toml`. There is none; both present → error.
+- A directory-form project config (e.g. `./.thoth/thoth.config.toml`).
+
+**Sequencing preference**: P21c → P21 → P21b. Landing P21c before P21 implementation lets P21's spec/plan/tests be written against the canonical names from the start. If P21 is mid-implementation when P21c is approved, fall back to a P21 → P21c → P21b ordering and accept the small sweep through P21's just-landed strings.
+
+**Open questions for the plan** (small items, do not block plan write-up)
+- Final spelling for the dotfile-form `init` flag: `--hidden` (recommended), `--dotfile`, or `--dot`.
+- Confirm `--force` overwrite semantics extend to `init --user` too.
+
+### Tests & Tasks
+- [ ] [P21c-TS01] Specify the test suite — canonical resolution at all three locations, ambiguity error on both project-root files, "config not found" error message includes any detected legacy paths, `init` flag combinations — before implementation.
+- [x] [P21c-T01] Write the implementation plan at `docs/superpowers/plans/2026-04-28-p21c-config-filename-standardization.md`, resolving the small open questions from the spec.
+- [ ] [P21c-TS02] `tests/test_config_filename.py` (or `tests/test_config.py`): user-tier loads `$XDG_CONFIG_HOME/thoth/thoth.config.toml` when present; raises `ConfigNotFoundError` (or treats as missing per existing optional-config behavior) when only the legacy `config.toml` exists, and the error message names the legacy file with the rename target.
+- [ ] [P21c-TS03] Project tier: `./thoth.config.toml` only → loads. `./.thoth.config.toml` only → loads. Both present → `ConfigAmbiguousError` with a "delete one before continuing" message naming both files. Neither present → returns empty/no-project-config (current optional-project-config semantics).
+- [ ] [P21c-TS04] Legacy detection helper is invoked only on the "config not found" error path. Regression guard: a successful canonical load asserts the legacy detector was not called.
+- [ ] [P21c-TS05] `thoth init` writes `./thoth.config.toml` by default. `thoth init --hidden` (or chosen spelling) writes `./.thoth.config.toml`. `thoth init --user` writes the user-tier canonical path. `--user` and `--hidden` are mutually exclusive. None of the three overwrite an existing canonical file without `--force`.
+- [ ] [P21c-T02] Update `src/thoth/paths.py`: `user_config_file()` returns the canonical user path. Do not add a `legacy_user_config_file()` helper; legacy paths live in the detection helper (T03) and nowhere else.
+- [ ] [P21c-T03] Update `src/thoth/config.py`: `project_config_paths = ["./thoth.config.toml", "./.thoth.config.toml"]`; `_load_project_config_with_path` raises `ConfigAmbiguousError` if both exist; user-tier load skips legacy filenames; add `detect_legacy_paths()` helper used only by the not-found error formatter.
+- [ ] [P21c-T04] Update `thoth init` (`src/thoth/cli_subcommands/...`): add `--user` and the dotfile flag, enforce mutual exclusion, respect existing `--force` semantics.
+- [ ] [P21c-T05] Add `ConfigNotFoundError` and `ConfigAmbiguousError` to `src/thoth/errors.py` (P21's `ConfigProfileError` is unchanged).
+- [ ] [P21c-T06] Sweep error messages, help text, and CLI strings (`src/thoth/help.py`, `src/thoth/errors.py`, `src/thoth/cli_subcommands/config.py`, `src/thoth/config.py`, etc.) to use the canonical filename.
+- [ ] [P21c-T07] Update `README.md` (config section, install/setup walkthrough, short "Migrating from earlier Thoth versions" note giving the rename mapping) and `manual_testing_instructions.md` (every smoke test that names a config path).
+- [ ] [P21c-T08] Update P21 and P21b spec/plan docs to use the canonical filename, or add a "see P21c" pointer per the chosen sequencing.
+- [ ] [P21c-T09] Update `PROJECTS.md` as implementation tasks land.
+
+### Automated Verification
+- `uv run pytest tests/test_config_filename.py tests/test_config.py -v` passes (test file name finalized in plan).
+- `just check` passes.
+- `./thoth_test -r --skip-interactive -q` passes.
+- `just test-lint` passes.
+- `just test-typecheck` passes.
+- `git diff --check` passes.
+
+---
+
 ## [ ] Project P22: OpenAI — Immediate (Synchronous) Calls
 **Goal**: Add standard, single-shot synchronous LLM completion calls via OpenAI.
 

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -14,7 +14,7 @@ This file tracks planned, active, and completed Thoth work. New projects are add
 
 Keep this summary list updated whenever a project is added, renamed, completed, dropped, or proceeded to a successor. The detailed project entry remains the source of truth; this summary is a quick navigation index.
 
-- [-] P21 — Configuration Profile Resolution & Overlay
+- [x] P21 — Configuration Profile Resolution & Overlay
 - [ ] P21b — Configuration Profile CRUD Commands (depends on P21)
 - [ ] P21c — Config Filename Standardization (`thoth.config.toml` everywhere)
 - [ ] P22 — OpenAI — Immediate (Synchronous) Calls
@@ -82,7 +82,7 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 
 ---
 
-## [-] Project P21: Configuration Profile Resolution & Overlay
+## [x] Project P21: Configuration Profile Resolution & Overlay
 **Goal**: Add CPP-style named configuration profile *resolution* — Thoth honors `--profile NAME`, `THOTH_PROFILE`, and `general.default_profile`, applies the selected `[profiles.<name>]` overlay between project config and env/CLI overrides, and hard-errors on missing profiles. Adds a `prompt_prefix` field with full hierarchy resolution (`profile.modes.X` > `profile` > `modes.X` > `general`; more specific replaces less specific), and ships example profiles via `thoth init` so users get a useful starter config out of the box.
 
 **References**
@@ -90,7 +90,7 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 - **Plan:** `docs/superpowers/plans/2026-04-28-p21-configuration-profiles.md`
 - **Research:** `research/configuration_profile_pattern.v1.md`
 
-**Status**: Complete — resolver/overlay/root-`--profile` plumbing landed on `feat/p21-config-profiles`.
+**Status**: Complete — resolver/overlay/root-`--profile` plumbing, `prompt_prefix` 4-level hierarchy, runtime wiring through `run_research`, shipped example profiles in `thoth init`, and the permutation test matrix all landed on `feat/p21-config-profiles`.
 
 **Scope**
 - Add profile sections under `[profiles.<name>]`, where nested profile keys mirror normal config paths.
@@ -124,13 +124,13 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 - [x] [P21-T05] Add root `--profile` to `_RESEARCH_OPTIONS`, inherited-option policy (`DEFAULT_HONOR` includes `"profile"`), root fallback parsing in `_extract_fallback_options`, and **every** existing config-loading call site, including `src/thoth/config_cmd.py` (`_load_manager` and each `get_config_*_data` entry that reads merged config) and `src/thoth/cli_subcommands/config.py` leaves that forward inherited profile.
 - [x] [P21-T06] Update `README.md`, `manual_testing_instructions.md`, and `src/thoth/help.py` with hand-edit profile examples (TOML structure, selection precedence, worked invocations). Documentation examples must show profiles that change the default mode/project, run all available deep-research providers (`["openai", "perplexity"]` today, with a "future-ready" callout pointing at gemini), force one deep-research provider, default to an immediate mode, and store a future-ready interactive default profile. README explains that `--profile`/`THOTH_PROFILE` are read-only runtime inputs and never mutate `general.default_profile`.
 - [x] [P21-T07] Update `PROJECTS.md` as implementation tasks land.
-- [ ] [P21-TS07] `tests/test_config_prompt_prefix.py`: hierarchy resolver — resolves `[profiles.X.modes.M]` > `[profiles.X]` > `[modes.M]` > `[general]` > `None`. More-specific REPLACES less-specific (no concat). Covers each tier, missing-key fallthrough, and empty-string handling.
-- [ ] [P21-TS08] `tests/test_config_profiles_permutations.py`: permutation matrix — `{flag, env, config-pointer, none}` × `{user-tier, project-tier, both}` × `{prefix-set, prefix-unset}` × `{deep_research, thinking, default}`. Each permutation gets a real TOML config fixture; assertions cover `cm.profile_selection`, the resolved `prompt_prefix`, and the final mode_config. Includes the shipped `init` examples.
-- [ ] [P21-TS09] `tests/test_run_prompt_prefix.py`: integration — when a profile is active and a `prompt_prefix` resolves, the assembled prompt that reaches the provider is `f"{prefix}\n\n{user_prompt}"`. The mode's `system_prompt` is unchanged. When no prefix resolves, the prompt is unchanged.
-- [ ] [P21-T08] Add `resolve_prompt_prefix(config, mode)` helper to `src/thoth/config_profiles.py` implementing the 4-level hierarchy.
-- [ ] [P21-T09] Wire `resolve_prompt_prefix` into `src/thoth/run.py:run_research` so the resolved prefix is prepended to the user prompt once at run entry; `operation.prompt` records the assembled prompt for resume parity.
-- [ ] [P21-T10] Update `src/thoth/commands.py:init_command` to ship example profiles in the generated `~/.config/thoth/config.toml`: `daily` (thinking + default project), `quick` (thinking), `openai_deep` (single-provider deep_research), `all_deep` (parallel openai+perplexity), `interactive` (interactive mode), and `deep_research` (deep_research with a worked `prompt_prefix` example demonstrating Q3a hierarchy).
-- [ ] [P21-T11] Document the `prompt_prefix` field and its hierarchy in `README.md` and `manual_testing_instructions.md`. Worked example: `[general] prompt_prefix`, `[modes.deep_research] prompt_prefix`, `[profiles.X] prompt_prefix`, `[profiles.X.modes.M] prompt_prefix` — show resolution outcome for each combination.
+- [x] [P21-TS07] `tests/test_config_prompt_prefix.py`: hierarchy resolver — resolves `[profiles.X.modes.M]` > `[profiles.X]` > `[modes.M]` > `[general]` > `None`. More-specific REPLACES less-specific (no concat). Covers each tier, missing-key fallthrough, and empty-string handling.
+- [x] [P21-TS08] `tests/test_config_profiles_permutations.py`: permutation matrix — `{flag, env, config-pointer, none}` × `{user-tier, project-tier, both}` × `{prefix-set, prefix-unset}` × `{deep_research, thinking, default}`. Each permutation gets a real TOML config fixture; assertions cover `cm.profile_selection`, the resolved `prompt_prefix`, and the final mode_config. Includes the shipped `init` examples.
+- [x] [P21-TS09] `tests/test_run_prompt_prefix.py`: integration — when a profile is active and a `prompt_prefix` resolves, the assembled prompt that reaches the provider is `f"{prefix}\n\n{user_prompt}"`. The mode's `system_prompt` is unchanged. When no prefix resolves, the prompt is unchanged.
+- [x] [P21-T08] Add `resolve_prompt_prefix(config, mode)` helper to `src/thoth/config_profiles.py` implementing the 4-level hierarchy.
+- [x] [P21-T09] Wire `resolve_prompt_prefix` into `src/thoth/run.py:run_research` so the resolved prefix is prepended to the user prompt once at run entry; `operation.prompt` records the assembled prompt for resume parity.
+- [x] [P21-T10] Update `src/thoth/commands.py:init_command` to ship example profiles in the generated `~/.config/thoth/config.toml`: `daily` (thinking + default project), `quick` (thinking), `openai_deep` (single-provider deep_research), `all_deep` (parallel openai+perplexity), `interactive` (interactive mode), and `deep_research` (deep_research with a worked `prompt_prefix` example demonstrating Q3a hierarchy).
+- [x] [P21-T11] Document the `prompt_prefix` field and its hierarchy in `README.md` and `manual_testing_instructions.md`. Worked example: `[general] prompt_prefix`, `[modes.deep_research] prompt_prefix`, `[profiles.X] prompt_prefix`, `[profiles.X.modes.M] prompt_prefix` — show resolution outcome for each combination.
 
 ### Automated Verification
 - `uv run pytest tests/test_config_profiles.py tests/test_config_cmd.py -v` passes.

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -14,7 +14,7 @@ This file tracks planned, active, and completed Thoth work. New projects are add
 
 Keep this summary list updated whenever a project is added, renamed, completed, dropped, or proceeded to a successor. The detailed project entry remains the source of truth; this summary is a quick navigation index.
 
-- [x] P21 — Configuration Profile Resolution & Overlay
+- [-] P21 — Configuration Profile Resolution & Overlay
 - [ ] P21b — Configuration Profile CRUD Commands (depends on P21)
 - [ ] P21c — Config Filename Standardization (`thoth.config.toml` everywhere)
 - [ ] P22 — OpenAI — Immediate (Synchronous) Calls
@@ -82,8 +82,8 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 
 ---
 
-## [x] Project P21: Configuration Profile Resolution & Overlay
-**Goal**: Add CPP-style named configuration profile *resolution* — Thoth honors `--profile NAME`, `THOTH_PROFILE`, and `general.default_profile`, applies the selected `[profiles.<name>]` overlay between project config and env/CLI overrides, and hard-errors on missing profiles. Users manage profiles by hand-editing TOML in this project; CRUD commands ship in P21b.
+## [-] Project P21: Configuration Profile Resolution & Overlay
+**Goal**: Add CPP-style named configuration profile *resolution* — Thoth honors `--profile NAME`, `THOTH_PROFILE`, and `general.default_profile`, applies the selected `[profiles.<name>]` overlay between project config and env/CLI overrides, and hard-errors on missing profiles. Adds a `prompt_prefix` field with full hierarchy resolution (`profile.modes.X` > `profile` > `modes.X` > `general`; more specific replaces less specific), and ships example profiles via `thoth init` so users get a useful starter config out of the box.
 
 **References**
 - **Spec:** `docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`
@@ -124,6 +124,13 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 - [x] [P21-T05] Add root `--profile` to `_RESEARCH_OPTIONS`, inherited-option policy (`DEFAULT_HONOR` includes `"profile"`), root fallback parsing in `_extract_fallback_options`, and **every** existing config-loading call site, including `src/thoth/config_cmd.py` (`_load_manager` and each `get_config_*_data` entry that reads merged config) and `src/thoth/cli_subcommands/config.py` leaves that forward inherited profile.
 - [x] [P21-T06] Update `README.md`, `manual_testing_instructions.md`, and `src/thoth/help.py` with hand-edit profile examples (TOML structure, selection precedence, worked invocations). Documentation examples must show profiles that change the default mode/project, run all available deep-research providers (`["openai", "perplexity"]` today, with a "future-ready" callout pointing at gemini), force one deep-research provider, default to an immediate mode, and store a future-ready interactive default profile. README explains that `--profile`/`THOTH_PROFILE` are read-only runtime inputs and never mutate `general.default_profile`.
 - [x] [P21-T07] Update `PROJECTS.md` as implementation tasks land.
+- [ ] [P21-TS07] `tests/test_config_prompt_prefix.py`: hierarchy resolver — resolves `[profiles.X.modes.M]` > `[profiles.X]` > `[modes.M]` > `[general]` > `None`. More-specific REPLACES less-specific (no concat). Covers each tier, missing-key fallthrough, and empty-string handling.
+- [ ] [P21-TS08] `tests/test_config_profiles_permutations.py`: permutation matrix — `{flag, env, config-pointer, none}` × `{user-tier, project-tier, both}` × `{prefix-set, prefix-unset}` × `{deep_research, thinking, default}`. Each permutation gets a real TOML config fixture; assertions cover `cm.profile_selection`, the resolved `prompt_prefix`, and the final mode_config. Includes the shipped `init` examples.
+- [ ] [P21-TS09] `tests/test_run_prompt_prefix.py`: integration — when a profile is active and a `prompt_prefix` resolves, the assembled prompt that reaches the provider is `f"{prefix}\n\n{user_prompt}"`. The mode's `system_prompt` is unchanged. When no prefix resolves, the prompt is unchanged.
+- [ ] [P21-T08] Add `resolve_prompt_prefix(config, mode)` helper to `src/thoth/config_profiles.py` implementing the 4-level hierarchy.
+- [ ] [P21-T09] Wire `resolve_prompt_prefix` into `src/thoth/run.py:run_research` so the resolved prefix is prepended to the user prompt once at run entry; `operation.prompt` records the assembled prompt for resume parity.
+- [ ] [P21-T10] Update `src/thoth/commands.py:init_command` to ship example profiles in the generated `~/.config/thoth/config.toml`: `daily` (thinking + default project), `quick` (thinking), `openai_deep` (single-provider deep_research), `all_deep` (parallel openai+perplexity), `interactive` (interactive mode), and `deep_research` (deep_research with a worked `prompt_prefix` example demonstrating Q3a hierarchy).
+- [ ] [P21-T11] Document the `prompt_prefix` field and its hierarchy in `README.md` and `manual_testing_instructions.md`. Worked example: `[general] prompt_prefix`, `[modes.deep_research] prompt_prefix`, `[profiles.X] prompt_prefix`, `[profiles.X.modes.M] prompt_prefix` — show resolution outcome for each combination.
 
 ### Automated Verification
 - `uv run pytest tests/test_config_profiles.py tests/test_config_cmd.py -v` passes.

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -28,6 +28,7 @@ Keep this summary list updated whenever a project is added, renamed, completed, 
 - [ ] P30 — Claude Code Skills Support
 - [ ] P31 — Interactive Init Command
 - [ ] P32 — Interactive Prompt Refiner
+- [ ] P33 — Schema-Driven Config Defaults (typed source for `thoth init` and `ConfigSchema`)
 - [ ] P20 — Extended Real-API Workflow Coverage — Mirror Mock Contracts
 - [ ] P18 — Immediate vs Background — Explicit `kind`, Runtime Mismatch, Path Split, Streaming, Cancel
 - [ ] P17 — thoth-ergonomics-v1 Spec Round-Trip — Annotate Implementation Status
@@ -399,6 +400,34 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 - [ ] [P32-T01] Flesh out requirements for the interactive prompt refiner.
 - [ ] [P32-T02] Implement an interactive workflow that refines a research prompt before submission.
 - [ ] [P32-T03] Keep the refiner fast and avoid full deep research during refinement.
+
+---
+
+## [ ] Project P33: Schema-Driven Config Defaults
+**Goal**: Drive every default config value — including `thoth init`'s starter document, `ConfigSchema.get_defaults()`, and `BUILTIN_MODES` — from a single typed source (Pydantic model or `@dataclass`-based schema). Eliminate the duplication between the runtime defaults and the init-template, and gain typechecker coverage for every key/value the project ships.
+
+**Status**: Placeholder — requirements still need to be fleshed out before this can be worked on.
+
+**Motivation (P21 follow-up)**: P21's tomlkit refactor (option 2 in the P21 retrospective) made the init writer structurally sound but didn't unify the two sources of "default config truth": `ConfigSchema.get_defaults()` (used by `ConfigManager.load_all_layers`) and `_build_starter_document()` (used by `thoth init`). A typo like `prompy_prefix` in the init template still slips past lint/typecheck today. Schema-driven generation closes that gap.
+
+**Scope (rough)**
+- Define a typed `StarterConfig` schema (Pydantic v2 or dataclasses) covering general/paths/execution/output/providers/profiles.
+- Refactor `ConfigSchema.get_defaults()` to derive its dict from the schema.
+- Refactor `_build_starter_document()` (and `_build_starter_profiles`) to serialize the schema via tomlkit instead of constructing tables by hand.
+- Add a regression test asserting `init`'s generated config round-trips through the schema with no validation errors.
+- Document migration in `README.md` if any default values change as a side-effect.
+
+**Out of Scope**
+- Changing the on-disk TOML schema or any default values.
+- Replacing `tomlkit` with another serializer.
+- Touching `BUILTIN_MODES` (it's mode-specific data, not config defaults).
+
+### Tests & Tasks
+- [ ] [P33-TS01] Design tests for schema-driven config generation before implementation.
+- [ ] [P33-T01] Flesh out requirements: pick the schema library (Pydantic v2 vs typed dataclasses), enumerate every key currently in `ConfigSchema.get_defaults()` and `_build_starter_document()`, and document the migration plan.
+- [ ] [P33-T02] Implement the typed `StarterConfig` schema and a serializer that emits tomlkit documents.
+- [ ] [P33-T03] Replace `ConfigSchema.get_defaults()` and `_build_starter_document()` to derive from the schema. Keep public API stable.
+- [ ] [P33-T04] Round-trip test: `init` output parses back to the schema with zero validation errors and matches `ConfigSchema.get_defaults()` byte-for-byte (after profile-stripping).
 
 ---
 

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -14,8 +14,9 @@ This file tracks planned, active, and completed Thoth work. New projects are add
 
 Keep this summary list updated whenever a project is added, renamed, completed, dropped, or proceeded to a successor. The detailed project entry remains the source of truth; this summary is a quick navigation index.
 
-- [ ] P21 — Configuration Profile Resolution & Overlay
+- [x] P21 — Configuration Profile Resolution & Overlay
 - [ ] P21b — Configuration Profile CRUD Commands (depends on P21)
+- [ ] P21c — Config Filename Standardization (`thoth.config.toml` everywhere)
 - [ ] P22 — OpenAI — Immediate (Synchronous) Calls
 - [ ] P23 — Perplexity — Immediate (Synchronous) Calls
 - [ ] P24 — Gemini — Immediate (Synchronous) Calls
@@ -81,7 +82,7 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 
 ---
 
-## [ ] Project P21: Configuration Profile Resolution & Overlay
+## [x] Project P21: Configuration Profile Resolution & Overlay
 **Goal**: Add CPP-style named configuration profile *resolution* — Thoth honors `--profile NAME`, `THOTH_PROFILE`, and `general.default_profile`, applies the selected `[profiles.<name>]` overlay between project config and env/CLI overrides, and hard-errors on missing profiles. Users manage profiles by hand-editing TOML in this project; CRUD commands ship in P21b.
 
 **References**
@@ -89,7 +90,7 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 - **Plan:** `docs/superpowers/plans/2026-04-28-p21-configuration-profiles.md`
 - **Research:** `research/configuration_profile_pattern.v1.md`
 
-**Status**: Planned — requirements scoped; implementation tasks unchecked.
+**Status**: Complete — resolver/overlay/root-`--profile` plumbing landed on `feat/p21-config-profiles`.
 
 **Scope**
 - Add profile sections under `[profiles.<name>]`, where nested profile keys mirror normal config paths.
@@ -112,17 +113,17 @@ Existing projects may use older labels such as `**Primary spec**`, `**Plan**`, o
 ### Tests & Tasks
 - [x] [P21-TS01] Specify the resolver/overlay test suite (resolver, `ConfigManager` overlay, root-flag plumbing) before implementation.
 - [x] [P21-T01] Flesh out requirements for configuration profile resolution using `research/configuration_profile_pattern.v1.md`.
-- [ ] [P21-TS02] `tests/test_config_profiles.py`: `resolve_profile_selection` uses `--profile` before `THOTH_PROFILE`, `THOTH_PROFILE` before `general.default_profile`, and no profile when all are absent.
-- [ ] [P21-TS03] `tests/test_config_profiles.py`: project profile shadows user profile of the same name wholesale; same-named profile tables are not merged.
-- [ ] [P21-TS04] `tests/test_config_profiles.py`: missing selected profile raises `ConfigProfileError` and names the selection source for each of `--profile` flag, `THOTH_PROFILE`, and `general.default_profile` pointer (load-time error per REQ-CPP-103).
-- [ ] [P21-T02] Add `src/thoth/config_profiles.py` with `ProfileSelection`, `ProfileLayer`, profile catalog collection, selection resolution, profile layer resolution, and profile stripping helpers.
-- [ ] [P21-T03] Add `ConfigProfileError` to `src/thoth/errors.py`.
-- [ ] [P21-TS05] `tests/test_config_profiles.py`: `ConfigManager` leaves behavior unchanged when no profile is active, applies active profile values, lets env/CLI per-setting values beat profile values, records the actual project config path (`./thoth.toml` or `./.thoth/config.toml`) used by `_load_project_config`, preserves `general.default_profile` after profile splitting, and `THOTH_PROFILE` is NOT in `_get_env_overrides` (regression guard).
-- [ ] [P21-T04] Update `ConfigManager.load_all_layers` to record the actual project config path used by `_load_project_config`, load raw user/project profiles, resolve the active profile, expose `profile_selection`/`active_profile`/`profile_catalog`, and merge a `profile` layer between project and env.
-- [ ] [P21-TS06] `tests/test_config_profiles.py`: root `--profile` reaches `thoth config get` and `thoth config list` (via `config_cmd._load_manager`); unknown root profile errors before command output; runtime `--profile`/`THOTH_PROFILE` does NOT mutate the persisted `general.default_profile` (B20: persisted `fast` + `--profile bar` → `config get` returns `fast`, and `cm.profile_selection.name == "bar"` from source `flag`).
-- [ ] [P21-T05] Add root `--profile` to `_RESEARCH_OPTIONS`, inherited-option policy (`DEFAULT_HONOR` includes `"profile"`), root fallback parsing in `_extract_fallback_options`, and **every** existing config-loading call site, including `src/thoth/config_cmd.py` (`_load_manager` and each `get_config_*_data` entry that reads merged config) and `src/thoth/cli_subcommands/config.py` leaves that forward inherited profile.
-- [ ] [P21-T06] Update `README.md`, `manual_testing_instructions.md`, and `src/thoth/help.py` with hand-edit profile examples (TOML structure, selection precedence, worked invocations). Documentation examples must show profiles that change the default mode/project, run all available deep-research providers (`["openai", "perplexity"]` today, with a "future-ready" callout pointing at gemini), force one deep-research provider, default to an immediate mode, and store a future-ready interactive default profile. README explains that `--profile`/`THOTH_PROFILE` are read-only runtime inputs and never mutate `general.default_profile`.
-- [ ] [P21-T07] Update `PROJECTS.md` as implementation tasks land.
+- [x] [P21-TS02] `tests/test_config_profiles.py`: `resolve_profile_selection` uses `--profile` before `THOTH_PROFILE`, `THOTH_PROFILE` before `general.default_profile`, and no profile when all are absent.
+- [x] [P21-TS03] `tests/test_config_profiles.py`: project profile shadows user profile of the same name wholesale; same-named profile tables are not merged.
+- [x] [P21-TS04] `tests/test_config_profiles.py`: missing selected profile raises `ConfigProfileError` and names the selection source for each of `--profile` flag, `THOTH_PROFILE`, and `general.default_profile` pointer (load-time error per REQ-CPP-103).
+- [x] [P21-T02] Add `src/thoth/config_profiles.py` with `ProfileSelection`, `ProfileLayer`, profile catalog collection, selection resolution, profile layer resolution, and profile stripping helpers.
+- [x] [P21-T03] Add `ConfigProfileError` to `src/thoth/errors.py`.
+- [x] [P21-TS05] `tests/test_config_profiles.py`: `ConfigManager` leaves behavior unchanged when no profile is active, applies active profile values, lets env/CLI per-setting values beat profile values, records the actual project config path (`./thoth.toml` or `./.thoth/config.toml`) used by `_load_project_config`, preserves `general.default_profile` after profile splitting, and `THOTH_PROFILE` is NOT in `_get_env_overrides` (regression guard).
+- [x] [P21-T04] Update `ConfigManager.load_all_layers` to record the actual project config path used by `_load_project_config`, load raw user/project profiles, resolve the active profile, expose `profile_selection`/`active_profile`/`profile_catalog`, and merge a `profile` layer between project and env.
+- [x] [P21-TS06] `tests/test_config_profiles.py`: root `--profile` reaches `thoth config get` and `thoth config list` (via `config_cmd._load_manager`); unknown root profile errors before command output; runtime `--profile`/`THOTH_PROFILE` does NOT mutate the persisted `general.default_profile` (B20: persisted `fast` + `--profile bar` → `config get` returns `fast`, and `cm.profile_selection.name == "bar"` from source `flag`).
+- [x] [P21-T05] Add root `--profile` to `_RESEARCH_OPTIONS`, inherited-option policy (`DEFAULT_HONOR` includes `"profile"`), root fallback parsing in `_extract_fallback_options`, and **every** existing config-loading call site, including `src/thoth/config_cmd.py` (`_load_manager` and each `get_config_*_data` entry that reads merged config) and `src/thoth/cli_subcommands/config.py` leaves that forward inherited profile.
+- [x] [P21-T06] Update `README.md`, `manual_testing_instructions.md`, and `src/thoth/help.py` with hand-edit profile examples (TOML structure, selection precedence, worked invocations). Documentation examples must show profiles that change the default mode/project, run all available deep-research providers (`["openai", "perplexity"]` today, with a "future-ready" callout pointing at gemini), force one deep-research provider, default to an immediate mode, and store a future-ready interactive default profile. README explains that `--profile`/`THOTH_PROFILE` are read-only runtime inputs and never mutate `general.default_profile`.
+- [x] [P21-T07] Update `PROJECTS.md` as implementation tasks land.
 
 ### Automated Verification
 - `uv run pytest tests/test_config_profiles.py tests/test_config_cmd.py -v` passes.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,88 @@ Configuration file is stored at `~/.thoth/config.toml`. Key settings:
 - `combine_reports`: Generate combined reports from multiple providers
 - `execution.prompt_max_bytes`: Max bytes accepted from `--prompt-file` (file path or stdin). Files exceeding this are rejected before reading. Default: `1048576` (1 MiB).
 
+### Configuration Profiles
+
+Profiles let you keep shared config at the top level and define named overlays for different work contexts.
+
+```toml
+[general]
+default_mode = "deep_research"
+
+[profiles.fast.general]
+default_mode = "thinking"
+```
+
+Selection precedence is `--profile` → `THOTH_PROFILE` → `general.default_profile` → no profile.
+
+`thoth config get general.default_profile` reflects the **persisted pointer** in the file. `--profile` and `THOTH_PROFILE` are read-only runtime inputs — they never write back to `general.default_profile`. With persisted `general.default_profile = "fast"`, running `thoth --profile bar config get general.default_profile` returns `"fast"`; the runtime active selection is `bar`.
+
+> **CLI management coming in P21b.** Today, manage profiles by editing `~/.config/thoth/config.toml` (or `./thoth.toml`/`./.thoth/config.toml` for project-scoped profiles) directly. The next project (P21b) adds `thoth config profiles list/show/current/use/clear/add/set/unset/remove` so you don't have to hand-edit.
+
+#### Change the default mode for a profile
+
+```toml
+[profiles.daily.general]
+default_mode = "thinking"
+default_project = "daily-notes"
+```
+
+```bash
+thoth --profile daily "summarize today's notes"
+```
+
+#### Run all available deep-research providers
+
+```toml
+[profiles.all_deep.general]
+default_mode = "deep_research"
+
+[profiles.all_deep.modes.deep_research]
+providers = ["openai", "perplexity"]
+parallel = true
+```
+
+```bash
+thoth --profile all_deep "compare vector databases"
+```
+
+> **Future-ready: gemini.** A `gemini` provider is planned (see `research/gemini-deep-research-api.v1.md`). Once it ships, you'll be able to add it to the `providers` list above. The profile schema is already future-ready; the runtime support lands in a later project — analogous to the interactive default-mode example below.
+
+#### Use one deep-research provider
+
+```toml
+[profiles.openai_deep.general]
+default_mode = "deep_research"
+
+[profiles.openai_deep.modes.deep_research]
+providers = ["openai"]
+parallel = false
+```
+
+```bash
+thoth --profile openai_deep "research model routing"
+```
+
+#### Use an immediate default mode
+
+```toml
+[profiles.quick.general]
+default_mode = "thinking"
+```
+
+```bash
+thoth --profile quick "give me the short version"
+```
+
+#### Reserve an interactive default profile
+
+```toml
+[profiles.interactive.general]
+default_mode = "interactive"
+```
+
+This profile can be stored, listed, and selected by P21 today (via hand-edit). The command behavior for a default interactive mode ships with a later interactive-default project.
+
 ## Provider Configuration
 
 ### OpenAI Provider

--- a/README.md
+++ b/README.md
@@ -401,6 +401,43 @@ default_mode = "interactive"
 
 This profile can be stored, listed, and selected by P21 today (via hand-edit). The command behavior for a default interactive mode ships with a later interactive-default project.
 
+#### Prepending a prompt prefix
+
+A `prompt_prefix` value is prepended (with a blank line) to the user's prompt before it reaches the LLM. The mode's `system_prompt` is unaffected. Resolution walks a 4-level hierarchy from most-specific to least:
+
+1. `[profiles.<active>.modes.<MODE>] prompt_prefix`
+2. `[profiles.<active>] prompt_prefix`
+3. `[modes.<MODE>] prompt_prefix`
+4. `[general] prompt_prefix`
+
+More-specific values **replace** less-specific ones (no concatenation). An empty string is treated as unset, so an inner-empty value falls through to the outer level.
+
+```toml
+[general]
+prompt_prefix = "Be precise."
+
+[modes.deep_research]
+prompt_prefix = "Cite primary sources."
+
+[profiles.deep.general]
+default_mode = "deep_research"
+prompt_prefix = "Be thorough. Cite primary sources where possible."
+
+[profiles.deep.modes.deep_research]
+prompt_prefix = "Be thorough. Cite primary sources. Include counter-arguments."
+```
+
+Resolution outcomes:
+
+| Active profile | Mode | Resolved prefix |
+|---|---|---|
+| (none) | `default` | `Be precise.` (general) |
+| (none) | `deep_research` | `Cite primary sources.` (modes.deep_research) |
+| `deep` | `default` | `Be thorough. Cite primary sources where possible.` (profiles.deep) |
+| `deep` | `deep_research` | `Be thorough. Cite primary sources. Include counter-arguments.` (profiles.deep.modes.deep_research) |
+
+`thoth init` ships these profiles pre-populated in your config (`~/.config/thoth/config.toml`): `daily`, `quick`, `openai_deep`, `all_deep`, `interactive`, and `deep_research` — the last one demonstrates the `prompt_prefix` hierarchy end-to-end. Edit or delete them as you like.
+
 ## Provider Configuration
 
 ### OpenAI Provider

--- a/docs/superpowers/plans/2026-04-28-p21c-config-filename-standardization.md
+++ b/docs/superpowers/plans/2026-04-28-p21c-config-filename-standardization.md
@@ -1,0 +1,549 @@
+# P21c Config Filename Standardization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tests are written before implementation in every task.
+
+**Goal:** Standardize Thoth's config filename to `thoth.config.toml`. One user-tier location (`$XDG_CONFIG_HOME/thoth/thoth.config.toml`) and two project-tier locations (`./thoth.config.toml` or `./.thoth.config.toml`, mutually exclusive — both present is a hard error). Legacy filenames (`config.toml` in user dir, `thoth.toml`, `.thoth/config.toml`) are no longer read. A "config not found" error path detects legacy files only to enrich the suggestion with rename guidance.
+
+**Architecture:** `paths.py` returns the canonical user path. `ConfigManager` loads exactly the canonical filenames; `_load_project_config_with_path` raises `ConfigAmbiguousError` if both project-tier files exist. A new `detect_legacy_paths()` helper lives in `config.py` and is called *only* by the "config not found" error formatter — never on the happy load path. `thoth init` gains `--user` and `--hidden` flags (mutually exclusive); `--force` semantics extend to `--user`.
+
+**Tech Stack:** Python 3.11+, Click 8.x, tomllib (read), existing `ConfigManager`, existing `init` command path, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-p21c-config-filename-standardization-design.md`
+**Tracking:** `PROJECTS.md` § "Project P21c: Config Filename Standardization"
+**Sequencing:** P21c → P21 → P21b preferred (lock canonical names before P21 implementation).
+
+---
+
+## File Map
+
+- Modify: `src/thoth/paths.py` — `user_config_file()` returns the canonical path.
+- Modify: `src/thoth/config.py` — `project_config_paths` shrinks to the two canonical names; `_load_project_config_with_path` raises on ambiguity; user-tier load skips legacy; new `detect_legacy_paths()` helper.
+- Modify: `src/thoth/errors.py` — add `ConfigNotFoundError`, `ConfigAmbiguousError`.
+- Modify: `src/thoth/commands.py` — `init_command` and `get_init_data` accept `user`, `hidden`, `force` parameters; respect mutual exclusion; write to the chosen target.
+- Modify: `src/thoth/cli_subcommands/init.py` — add `--user`, `--hidden`, `--force` Click options; enforce mutual exclusion at the Click layer; thread through to `init_command` / `get_init_data`.
+- Modify: `src/thoth/help.py`, `src/thoth/cli_subcommands/config.py` — string sweep for canonical filename.
+- Modify: `README.md`, `manual_testing_instructions.md` — canonical filename + short "Migrating from earlier Thoth versions" note.
+- Modify: `docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`, `.../p21b-...crud-design.md`, `docs/superpowers/plans/2026-04-28-p21-configuration-profiles.md`, `.../p21b-...crud.md` — replace legacy filenames with canonical names.
+- Modify: `PROJECTS.md` — task-by-task progress.
+- Test: `tests/test_config_filename.py` — new file, owns all P21c scenarios.
+
+P21c does NOT touch profile resolution code (P21) or profile CRUD (P21b) beyond canonical-name string updates in their docs.
+
+---
+
+## Test Scenario Matrix
+
+Every scenario below maps to a named test in `tests/test_config_filename.py`. The matrix is the contract — Task 1 writes these tests first, all failing, before any implementation moves.
+
+### A. User-tier loading
+
+| ID | Scenario | Expected |
+|---|---|---|
+| A1 | `~/.config/thoth/thoth.config.toml` exists | Loads it; `cm.user_config_path` points to it. |
+| A2 | Only legacy `~/.config/thoth/config.toml` exists (canonical absent) | Treated as no user config (existing optional-user-config behavior). Legacy file is **not** loaded. `cm.user_config_path` is the canonical path (which doesn't exist). |
+| A3 | Both canonical and legacy user files exist | Canonical loads; legacy ignored silently (no warning, no error — they are different filenames at different paths and ambiguity rule applies only at the project tier). |
+| A4 | Neither user file exists, no project file either, command requires config | `ConfigNotFoundError` raised; message lists the canonical user path **and** the canonical project paths. |
+| A5 | Same as A4 but legacy `config.toml` is on disk | `ConfigNotFoundError` message additionally names the legacy path with rename target (`thoth.config.toml`). |
+
+### B. Project-tier loading
+
+| ID | Scenario | Expected |
+|---|---|---|
+| B1 | Only `./thoth.config.toml` exists | Loads it; `cm.project_config_path` points to it. |
+| B2 | Only `./.thoth.config.toml` exists | Loads it; `cm.project_config_path` points to it. |
+| B3 | Both `./thoth.config.toml` and `./.thoth.config.toml` exist | `ConfigAmbiguousError` raised. Message names both files and tells the user to delete one. No precedence. |
+| B4 | Neither canonical project file exists | Returns no project config (existing optional-project-config behavior). |
+| B5 | Only legacy `./thoth.toml` exists | Treated as no project config. Legacy file is **not** loaded. |
+| B6 | Only legacy `./.thoth/config.toml` exists | Treated as no project config. Legacy file is **not** loaded. |
+| B7 | `ConfigNotFoundError` path with legacy `./thoth.toml` on disk | Error suggestion names the legacy file and the rename target. |
+| B8 | `ConfigNotFoundError` path with legacy `./.thoth/config.toml` on disk | Error suggestion names the legacy file and the rename target. |
+
+### C. Legacy detection helper
+
+| ID | Scenario | Expected |
+|---|---|---|
+| C1 | `detect_legacy_paths()` returns only paths that exist | Pure function; no side effects. |
+| C2 | Successful load (canonical files present) does NOT call `detect_legacy_paths()` | Spy / monkeypatch confirms zero calls. Regression guard against accidental fallback-by-accident. |
+| C3 | `ConfigNotFoundError` formatter calls `detect_legacy_paths()` exactly once | Spy / monkeypatch confirms one call. |
+
+### D. `thoth init` flag combinations
+
+| ID | Invocation | Target | Notes |
+|---|---|---|---|
+| D1 | `thoth init` | `./thoth.config.toml` | Default project write. |
+| D2 | `thoth init --hidden` | `./.thoth.config.toml` | Dotfile form. |
+| D3 | `thoth init --user` | `$XDG_CONFIG_HOME/thoth/thoth.config.toml` | User-tier write. Creates parent dir if missing. |
+| D4 | `thoth init --user --hidden` | ERROR | Mutual exclusion enforced at Click layer (UsageError). |
+| D5 | `thoth init` when `./thoth.config.toml` already exists, no `--force` | Refuses to overwrite; error. |
+| D6 | `thoth init --force` when `./thoth.config.toml` exists | Overwrites. |
+| D7 | `thoth init --user` when user file exists, no `--force` | Refuses to overwrite; error. |
+| D8 | `thoth init --user --force` when user file exists | Overwrites. *(Confirmed in spec §9 Q2.)* |
+| D9 | `thoth init --hidden` when `./thoth.config.toml` already exists (no `--force`) | Writes `./.thoth.config.toml`. The next `thoth` invocation hits B3 ambiguity — this is documented but is **not** prevented at `init` time (B3 catches it on next load, with a clearer error than `init` could give pre-write). |
+| D10 | `thoth init --hidden --force` when `./.thoth.config.toml` exists | Overwrites `./.thoth.config.toml`. |
+| D11 | `thoth init --json --non-interactive` | Honors `--user` and `--hidden` selection in the JSON envelope (`config_path` field reflects target). |
+
+### E. String sweep regression guards
+
+| ID | Scenario | Expected |
+|---|---|---|
+| E1 | `grep -r "config.toml" src/ tests/` excluding the legacy detector and docstrings | Only canonical references remain. |
+| E2 | `grep -r "thoth.toml" src/ tests/` excluding the legacy detector | Only canonical references remain. |
+| E3 | `grep -r "\.thoth/config" src/ tests/` excluding the legacy detector | Only canonical references remain. |
+
+E1–E3 run as actual pytest assertions over file contents, not just a grep — the test reads files and asserts no forbidden tokens outside the allowlisted lines.
+
+---
+
+## Task 1: Test Scenario Matrix as Failing Tests
+
+**Files:**
+- Create: `tests/test_config_filename.py`
+
+- [ ] **Step 1: Skeleton with imports and fixtures**
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from thoth.config import ConfigManager, detect_legacy_paths
+from thoth.errors import ConfigAmbiguousError, ConfigNotFoundError
+from thoth.paths import user_config_file
+
+
+@pytest.fixture
+def isolated_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate XDG_CONFIG_HOME and CWD into tmp_path/{xdg, project}."""
+    xdg = tmp_path / "xdg"
+    project = tmp_path / "project"
+    xdg.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.chdir(project)
+    return tmp_path
+```
+
+- [ ] **Step 2: Write A1–A5 user-tier tests** (failing — module/symbols don't exist yet).
+- [ ] **Step 3: Write B1–B8 project-tier tests** including the `ConfigAmbiguousError` assertions.
+- [ ] **Step 4: Write C1–C3 legacy-detection helper tests.** C2 uses `monkeypatch.setattr` on `thoth.config.detect_legacy_paths` to assert zero calls during a successful load.
+- [ ] **Step 5: Write D1–D11 init-flag tests** using `click.testing.CliRunner`. D4 asserts `result.exit_code != 0` and `"mutually exclusive"` in stderr.
+- [ ] **Step 6: Write E1–E3 string-sweep tests** that walk `src/` and `tests/` and assert forbidden tokens appear only on allowlisted lines.
+
+- [ ] **Step 7: Verify all tests fail** with `ImportError` / `AttributeError` (symbols don't exist yet) or `AssertionError`. This is the red phase.
+
+```bash
+uv run pytest tests/test_config_filename.py -v
+# All A/B/C/D/E tests should fail or error.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/test_config_filename.py
+git commit -m "test(p21c): add failing test scenario matrix for canonical config filename"
+```
+
+---
+
+## Task 2: Path Helper and Error Classes
+
+**Files:**
+- Modify: `src/thoth/paths.py`
+- Modify: `src/thoth/errors.py`
+
+- [ ] **Step 1: Update `user_config_file()`**
+
+```python
+# src/thoth/paths.py
+def user_config_file() -> Path:
+    return user_config_dir() / "thoth.config.toml"
+```
+
+Do **not** add a `legacy_user_config_file()` helper. The legacy path lives only inside `detect_legacy_paths()` in Task 3.
+
+- [ ] **Step 2: Add error classes**
+
+```python
+# src/thoth/errors.py
+class ConfigNotFoundError(ThothError):
+    """No canonical Thoth config file found at any expected location."""
+
+class ConfigAmbiguousError(ThothError):
+    """Both canonical project-tier config files exist; user must pick one."""
+```
+
+Match the existing `ThothError` constructor pattern (message + suggestion) used by `ConfigProfileError`.
+
+- [ ] **Step 3: Verify A1, B1, B2 now pass partially**
+
+A1/B1/B2 should reach further into `ConfigManager` than they did. Some will still fail on Task 3 changes — that's expected. C2 should now fail with `ImportError` on `detect_legacy_paths` (we add it in Task 3).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/thoth/paths.py src/thoth/errors.py
+git commit -m "feat(p21c): canonical user_config_file() and config error classes"
+```
+
+---
+
+## Task 3: Loader Changes
+
+**Files:**
+- Modify: `src/thoth/config.py`
+
+- [ ] **Step 1: Update `project_config_paths` and ambiguity check**
+
+```python
+# src/thoth/config.py
+class ConfigManager:
+    def __init__(self, config_path: Path | None = None):
+        self.user_config_path = config_path or user_config_file()
+        self.project_config_paths = [
+            "./thoth.config.toml",
+            "./.thoth.config.toml",
+        ]
+        ...
+```
+
+In `_load_project_config_with_path` (or the equivalent helper):
+
+```python
+def _load_project_config_with_path(self) -> tuple[dict[str, Any], Path | None]:
+    candidates = [Path(p) for p in self.project_config_paths]
+    existing = [p for p in candidates if p.exists()]
+    if len(existing) > 1:
+        raise ConfigAmbiguousError(
+            f"Two Thoth config files found in the project root:\n"
+            f"  {existing[0]}\n"
+            f"  {existing[1]}\n"
+            f"\nDelete one before continuing. They are not merged and Thoth "
+            f"will not pick between them.",
+        )
+    if not existing:
+        return {}, None
+    return self._load_toml_file(existing[0]), existing[0]
+```
+
+User-tier load: keep the current `if self.user_config_path.exists()` check; do **not** add a legacy fallback path.
+
+- [ ] **Step 2: Add `detect_legacy_paths()` helper**
+
+```python
+# src/thoth/config.py — module level, not on ConfigManager.
+LEGACY_USER_FILENAME = "config.toml"
+LEGACY_PROJECT_PATHS: tuple[str, ...] = ("./thoth.toml", "./.thoth/config.toml")
+
+
+def detect_legacy_paths() -> list[Path]:
+    """Return any legacy Thoth config files that exist on disk.
+
+    Used to enrich 'config not found' error messages — never to load.
+    """
+    found: list[Path] = []
+    legacy_user = user_config_dir() / LEGACY_USER_FILENAME
+    if legacy_user.exists():
+        found.append(legacy_user)
+    for rel in LEGACY_PROJECT_PATHS:
+        p = Path(rel)
+        if p.exists():
+            found.append(p)
+    return found
+```
+
+C2 (regression guard) requires that `detect_legacy_paths` is **not** called from any code path that runs during a successful `load_all_layers`. Verify by structuring `config.py` so the only call site is the `ConfigNotFoundError` formatter.
+
+- [ ] **Step 3: Wire `ConfigNotFoundError` raise + formatter**
+
+Identify the call sites that today silently tolerate "no config" vs those that require config to be present. P21c does not change *which* commands require config — it only changes the error message when a required-config command runs without one.
+
+The formatter:
+
+```python
+def _format_config_not_found() -> ConfigNotFoundError:
+    canonical = [
+        str(user_config_file()),
+        "./thoth.config.toml",
+        "./.thoth.config.toml",
+    ]
+    legacy = detect_legacy_paths()
+    lines = ["No Thoth config found.", "  Looked for:"]
+    for path in canonical:
+        lines.append(f"    {path}")
+    if legacy:
+        lines.append("")
+        if len(legacy) == 1:
+            lines.append(f"  Detected legacy file: {legacy[0]}")
+        else:
+            lines.append("  Detected legacy files:")
+            for p in legacy:
+                lines.append(f"    {p}")
+        lines.append(
+            "  These filenames are no longer read. Rename to "
+            "thoth.config.toml (or .thoth.config.toml in the project root)."
+        )
+    return ConfigNotFoundError("\n".join(lines))
+```
+
+- [ ] **Step 4: Run A1–C3**
+
+```bash
+uv run pytest tests/test_config_filename.py -k "test_a or test_b or test_c" -v
+```
+
+All A and B and C tests should pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/thoth/config.py
+git commit -m "feat(p21c): canonical-only config loading with ambiguity error and legacy-detection helper"
+```
+
+---
+
+## Task 4: `thoth init` — `--user`, `--hidden`, `--force`
+
+**Files:**
+- Modify: `src/thoth/cli_subcommands/init.py`
+- Modify: `src/thoth/commands.py`
+
+- [ ] **Step 1: Update `init_command` / `get_init_data` signatures**
+
+```python
+# src/thoth/commands.py
+def init_command(
+    self,
+    config_path: Path | None = None,
+    *,
+    user: bool = False,
+    hidden: bool = False,
+    force: bool = False,
+    **params,
+) -> None:
+    if user and hidden:
+        raise ThothError(
+            "thoth init: --user and --hidden are mutually exclusive",
+        )
+
+    target = self._resolve_init_target(config_path, user=user, hidden=hidden)
+    if target.exists() and not force:
+        raise ThothError(
+            f"thoth init: refusing to overwrite existing {target}. "
+            f"Pass --force to overwrite.",
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    self._write_default_config(target)
+```
+
+```python
+def _resolve_init_target(
+    self,
+    config_path: Path | None,
+    *,
+    user: bool,
+    hidden: bool,
+) -> Path:
+    if config_path is not None:
+        return Path(config_path).expanduser().resolve()
+    if user:
+        return user_config_file()
+    if hidden:
+        return Path("./.thoth.config.toml").resolve()
+    return Path("./thoth.config.toml").resolve()
+```
+
+`get_init_data` mirrors the same parameter set so D11 (JSON envelope reflects target) passes:
+
+```python
+def get_init_data(
+    *,
+    non_interactive: bool,
+    config_path: str | None,
+    user: bool = False,
+    hidden: bool = False,
+    force: bool = False,
+) -> dict:
+    ...
+```
+
+- [ ] **Step 2: Update Click leaf**
+
+```python
+# src/thoth/cli_subcommands/init.py
+@click.command(name="init")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON envelope")
+@click.option("--non-interactive", is_flag=True, help="Skip interactive prompts (required with --json)")
+@click.option("--user", "user", is_flag=True, help="Write to the user-tier config (XDG)")
+@click.option("--hidden", "hidden", is_flag=True, help="Write to ./.thoth.config.toml instead of ./thoth.config.toml")
+@click.option("--force", "force", is_flag=True, help="Overwrite an existing config file")
+@click.pass_context
+def init(
+    ctx: click.Context,
+    as_json: bool,
+    non_interactive: bool,
+    user: bool,
+    hidden: bool,
+    force: bool,
+) -> None:
+    if user and hidden:
+        raise click.UsageError("--user and --hidden are mutually exclusive")
+    ...
+```
+
+The `click.UsageError` raise is what makes D4 pass cleanly with a non-zero exit code and a clear message.
+
+- [ ] **Step 3: Run D1–D11**
+
+```bash
+uv run pytest tests/test_config_filename.py -k "test_d" -v
+```
+
+All D tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/thoth/cli_subcommands/init.py src/thoth/commands.py
+git commit -m "feat(p21c): thoth init --user, --hidden, --force flags"
+```
+
+---
+
+## Task 5: String Sweep — Source Code
+
+**Files:**
+- Modify: `src/thoth/help.py`
+- Modify: `src/thoth/cli_subcommands/config.py`
+- Modify: any other `src/**/*.py` containing legacy filename literals (audit via `grep`).
+
+- [ ] **Step 1: Inventory**
+
+```bash
+grep -rn "config.toml\|thoth.toml\|\.thoth/" src/thoth/ \
+  | grep -v "detect_legacy_paths\|LEGACY_USER_FILENAME\|LEGACY_PROJECT_PATHS\|test_"
+```
+
+Each remaining hit is a candidate. Update text strings (help, error messages, docstrings) to canonical forms. Code that names paths via `user_config_file()` / `project_config_paths` is already canonical and needs no change.
+
+- [ ] **Step 2: Run E1–E3**
+
+```bash
+uv run pytest tests/test_config_filename.py -k "test_e" -v
+```
+
+E1–E3 are the regression guards for this sweep.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/
+git commit -m "refactor(p21c): sweep source strings to canonical thoth.config.toml"
+```
+
+---
+
+## Task 6: Documentation Sweep
+
+**Files:**
+- Modify: `README.md`
+- Modify: `manual_testing_instructions.md`
+- Modify: `docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`
+- Modify: `docs/superpowers/specs/2026-04-28-p21b-configuration-profiles-crud-design.md`
+- Modify: `docs/superpowers/plans/2026-04-28-p21-configuration-profiles.md`
+- Modify: `docs/superpowers/plans/2026-04-28-p21b-configuration-profiles-crud.md`
+- Audit + modify if found: `CLAUDE.md`, `AGENTS.md`, `planning/*.md`.
+
+- [ ] **Step 1: Inventory doc references**
+
+```bash
+grep -rn "config.toml\|thoth.toml\|\.thoth/config" \
+  README.md manual_testing_instructions.md docs/ planning/ CLAUDE.md AGENTS.md \
+  2>/dev/null
+```
+
+- [ ] **Step 2: README — config section + migration note**
+
+Add a short "Migrating from earlier Thoth versions" callout in the config section:
+
+```markdown
+### Migrating from earlier Thoth versions
+
+Thoth previously read three different filenames depending on location. Starting with vX.Y.0, the canonical name is `thoth.config.toml` everywhere:
+
+| Old | New |
+|---|---|
+| `~/.config/thoth/config.toml` | `~/.config/thoth/thoth.config.toml` |
+| `./thoth.toml` | `./thoth.config.toml` *or* `./.thoth.config.toml` |
+| `./.thoth/config.toml` | `./.thoth.config.toml` *or* `./thoth.config.toml` |
+
+The old filenames are no longer read. Rename them with `mv`. If both `./thoth.config.toml` and `./.thoth.config.toml` exist in the same project, Thoth will refuse to start until one is deleted.
+```
+
+- [ ] **Step 3: P21 + P21b spec/plan rewrites**
+
+Per the sequencing preference (P21c → P21 → P21b), the P21 and P21b spec/plan documents are still in draft. Update every legacy filename literal in those four files to canonical forms. Examples to grep for in those four files:
+
+- `./thoth.toml` → `./thoth.config.toml`
+- `./.thoth/config.toml` → `./.thoth.config.toml`
+- `~/.config/thoth/config.toml` → `~/.config/thoth/thoth.config.toml`
+
+If the P21 spec's "the catalog records the actual project config path (`./thoth.toml` or `./.thoth/config.toml`)" line still exists, replace with the canonical pair `(./thoth.config.toml or ./.thoth.config.toml)`.
+
+- [ ] **Step 4: manual_testing_instructions.md**
+
+Update every smoke test that writes or names a config path. Pay special attention to any test that creates `./thoth.toml` as a fixture — those become `./thoth.config.toml`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md manual_testing_instructions.md docs/ planning/ CLAUDE.md AGENTS.md
+git commit -m "docs(p21c): sweep documentation to canonical thoth.config.toml"
+```
+
+---
+
+## Task 7: PROJECTS.md Progress Updates
+
+**Files:**
+- Modify: `PROJECTS.md`
+
+- [ ] **Step 1: As each task above lands, check its `[P21c-T##]` / `[P21c-TS##]` box.**
+- [ ] **Step 2: Final commit when all P21c tasks are checked**
+
+```bash
+git add PROJECTS.md
+git commit -m "chore(p21c): mark implementation tasks complete in PROJECTS.md"
+```
+
+---
+
+## Final Verification (run before declaring P21c done)
+
+- [ ] `uv run pytest tests/test_config_filename.py tests/test_config.py tests/test_config_cmd.py -v` — all pass.
+- [ ] `just check` passes.
+- [ ] `./thoth_test -r --skip-interactive -q` passes.
+- [ ] `just test-lint` passes.
+- [ ] `just test-typecheck` passes.
+- [ ] `git diff --check` passes.
+- [ ] Manual smoke (one fresh shell):
+  - `thoth init` in an empty dir → file at `./thoth.config.toml`.
+  - `thoth init --hidden` in another empty dir → file at `./.thoth.config.toml`.
+  - Touch both files in the same dir → next `thoth config get general.default_mode` (or any config-loading command) errors with `ConfigAmbiguousError`.
+  - `thoth init --user` → file at `~/.config/thoth/thoth.config.toml`.
+  - `thoth init --user --hidden` → `UsageError: --user and --hidden are mutually exclusive`.
+  - Place a legacy `./thoth.toml`, no canonical → command requiring config errors with the canonical paths listed AND the legacy file named in the suggestion.
+
+---
+
+## Risk Register
+
+| Risk | Mitigation |
+|---|---|
+| Users on existing installs get a "config not found" error after upgrading. | The error names the legacy file and the rename target. README migration note documents it. Release notes call it out as a breaking change in the version bump. |
+| Sequencing slip — P21c lands after P21 implementation. | Task 6 Step 3 already accounts for this: it sweeps P21 and P21b spec/plan docs whether they're draft or already implemented. If P21 is implemented first, add a small follow-up sub-task to also sweep P21's `tests/test_config_profiles.py` literals. |
+| Test E1–E3 false positives from third-party docs in `tests/fixtures/`. | The string-sweep test allowlists known fixture paths. Audit during Task 1 Step 6. |
+| `init --hidden` after a legacy `./thoth.toml` exists creates a confusing two-file state. | Documented in D9. Spec position: B3 ambiguity catches this on the next load with a clearer message than `init` could give pre-write. If user feedback shows this is too subtle, add a follow-up project that has `init` warn when legacy files are detected at write time. |

--- a/docs/superpowers/specs/2026-04-28-p21c-config-filename-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-28-p21c-config-filename-standardization-design.md
@@ -1,0 +1,229 @@
+# Design — Config Filename Standardization (P21c)
+
+**Status:** Draft for review (decisions locked 2026-04-28; ready for plan)
+**Created:** 2026-04-28
+**Project ID:** P21c
+**Target version:** v3.2.0 (land before P21 implementation if possible — see §7)
+**Tracking:** `PROJECTS.md` § "Project P21c: Config Filename Standardization"
+**Related:** P21 (`docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`), P21b (`docs/superpowers/specs/2026-04-28-p21b-configuration-profiles-crud-design.md`)
+
+---
+
+## 1. Goal
+
+Standardize the Thoth config filename to **`thoth.config.toml`**. There is **one** user-tier location and **two** project-tier locations (mutually exclusive). The filename alone uniquely identifies a Thoth config file regardless of where it lives.
+
+| Tier | Today | After P21c |
+|---|---|---|
+| User (XDG) | `$XDG_CONFIG_HOME/thoth/config.toml` | `$XDG_CONFIG_HOME/thoth/thoth.config.toml` |
+| Project — visible | `./thoth.toml` | `./thoth.config.toml` |
+| Project — hidden | `./.thoth/config.toml` (dir form) | `./.thoth.config.toml` (dotfile form) |
+
+**No legacy fallback.** The old filenames stop being read entirely. Users with existing config files must rename them.
+
+**Both project-tier files present → hard error.** Thoth refuses to choose; the user must delete one. There is no precedence rule between `./thoth.config.toml` and `./.thoth.config.toml`.
+
+## 2. Motivation
+
+Thoth currently uses three different filenames depending on where the file lives:
+
+- `config.toml` (user XDG dir) — generic, only meaningful because of the surrounding `thoth/` directory.
+- `thoth.toml` (project root) — specific, but a different name from the user file.
+- `config.toml` again (project `.thoth/` dir) — same as the user file, but ambiguous when seen out of context.
+
+This creates friction:
+
+- **Identification.** A user opening `~/.config/thoth/config.toml` in an editor sees a tab labeled `config.toml` with no provenance. A `thoth.config.toml` tab is unambiguous.
+- **Search.** `grep -r thoth.config.toml .` locates every Thoth config; today there is no single filename that works.
+- **Documentation.** README, help text, manual-testing notes, and error messages all have to qualify which config file they mean. One filename collapses that.
+- **Mental model.** Users have to remember three names and which goes where. One name removes the rule.
+
+The trade-off is a mildly redundant XDG path (`thoth/thoth.config.toml`). That redundancy is the *intended* cost of "filename identifies it" — it is not accidental.
+
+## 3. Decisions
+
+### Q1. What is the canonical filename? *(locked)*
+
+`thoth.config.toml`. Rationale:
+
+- `thoth.` prefix → unambiguous tool identification regardless of directory.
+- `.config.` infix → matches the existing convention shared by tools like `vite.config.ts`, `prettier.config.js`, where `<tool>.config.<ext>` reads as "the config for this tool."
+- `.toml` suffix → unchanged file format.
+
+### Q2. Backwards compatibility? *(locked — none)*
+
+No legacy fallback. The loader does **not** read `~/.config/thoth/config.toml`, `./thoth.toml`, or `./.thoth/config.toml`. After P21c lands, those files are inert.
+
+When no canonical config is found, Thoth raises a clear "config not found" error. **As a UX courtesy** (not a fallback), the error message *checks for* legacy filenames at the same paths and, if any are present, names them in the suggestion text:
+
+```text
+No Thoth config found.
+  Looked for: ~/.config/thoth/thoth.config.toml
+              ./thoth.config.toml
+              ./.thoth.config.toml
+
+  Detected legacy file: ./thoth.toml
+  This filename is no longer read. Rename it to ./thoth.config.toml or ./.thoth.config.toml.
+```
+
+The detection is purely informational. It runs only on the "config not found" path; it does not load the legacy file or fire on the happy path.
+
+### Q3. How are the two project-tier filenames resolved? *(locked — error on ambiguity)*
+
+`./thoth.config.toml` and `./.thoth.config.toml` are equally acceptable. There is **no precedence**. If both exist in the same project root, Thoth raises `ConfigAmbiguousError` and asks the user to delete one:
+
+```text
+Two Thoth config files found in the project root:
+  ./thoth.config.toml
+  ./.thoth.config.toml
+
+Delete one before continuing. They are not merged and Thoth will not pick between them.
+```
+
+Rationale: precedence in this case is arbitrary (no semantic difference between visible and dotfile forms), and silently picking one is worse than refusing — a user who edits the "wrong" one would never see their changes apply.
+
+The check fires whenever Thoth resolves a project config path: at config load and at any CLI command that resolves the project file (e.g. mutator `config` leaves and `init`).
+
+### Q4. Does this change `init`? *(locked — yes, both forms)*
+
+Yes:
+
+- `thoth init` (project) writes `./thoth.config.toml` by default. A flag to write the dotfile form (`./.thoth.config.toml`) instead is included — see §4.3 for the exact spelling.
+- `thoth init --user` writes `$XDG_CONFIG_HOME/thoth/thoth.config.toml`. This is in scope (P21c-T04).
+- `init` refuses to overwrite an existing canonical file unless `--force` is passed (existing `init` behavior; documented here only for completeness).
+- `init` does **not** auto-rename legacy files. If the user has `./thoth.toml` and runs `thoth init`, the new file is written alongside; the next `thoth` invocation hits the §3 Q3 ambiguity case (legacy file ignored, canonical loaded — see §3 Q2: legacy detection is informational only and does not block load when canonical is present). The "Detected legacy file" notice still appears in any error path.
+
+### Q5. Does this affect the `[profiles.<name>]` overlay? *(locked — no)*
+
+P21 lives entirely *inside* whichever config file is loaded. The filename change is orthogonal to P21's selection/overlay logic. The only intersection is that P21 spec strings, error messages, and tests refer to the legacy filenames; those references are updated in P21c as part of the docs sweep.
+
+## 4. Architecture
+
+### 4.1 `src/thoth/paths.py`
+
+```python
+def user_config_file() -> Path:
+    return user_config_dir() / "thoth.config.toml"
+```
+
+The legacy `legacy_user_config_file()` helper proposed in the earlier draft is **not** added. Legacy detection lives in the error-path helper (§4.4), not in `paths.py`.
+
+### 4.2 `src/thoth/config.py`
+
+`ConfigManager.__init__`:
+
+```python
+self.project_config_paths = [
+    "./thoth.config.toml",
+    "./.thoth.config.toml",
+]
+```
+
+`_load_project_config_with_path()`:
+
+1. Find which of the two canonical paths exist.
+2. If both → raise `ConfigAmbiguousError` (see §4.5).
+3. If exactly one → load it and return `(data, path)`.
+4. If neither → return `({}, None)` (project config is optional, same as today).
+
+User-tier loading: load `user_config_file()` if it exists; if not, treat as missing (no fallback). The "config not found" error handler runs the legacy detector and embellishes the message.
+
+### 4.3 `thoth init`
+
+- `thoth init` → writes `./thoth.config.toml`.
+- `thoth init --hidden` (or `--dotfile` — final spelling decided in plan) → writes `./.thoth.config.toml` instead.
+- `thoth init --user` → writes `$XDG_CONFIG_HOME/thoth/thoth.config.toml`.
+- `--user` and `--hidden` are mutually exclusive.
+- All three respect existing `--force` overwrite semantics.
+
+The exact flag name (`--hidden` vs `--dotfile` vs `--dot`) is a small open question for the plan; the *capability* is locked.
+
+### 4.4 Legacy detection helper (informational only)
+
+A small helper centralizes legacy-file detection so the error path is the *only* place that knows about legacy names:
+
+```python
+LEGACY_USER_PATH = user_config_dir() / "config.toml"
+LEGACY_PROJECT_PATHS = ("./thoth.toml", "./.thoth/config.toml")
+
+def detect_legacy_paths() -> list[Path]:
+    """Return any legacy Thoth config files that exist on disk.
+    Used to enrich 'config not found' error messages — never to load.
+    """
+    ...
+```
+
+Called only from the "no config found" error formatter. Never invoked on the happy path. Tests assert that successful loads do not call it.
+
+### 4.5 Errors
+
+`src/thoth/errors.py` adds two error classes:
+
+- `ConfigNotFoundError(ThothError)` — raised when config is required but no canonical file exists. Message includes the canonical paths Thoth looked at and any detected legacy files (§3 Q2 wording).
+- `ConfigAmbiguousError(ThothError)` — raised when both `./thoth.config.toml` and `./.thoth.config.toml` exist (§3 Q3 wording).
+
+`ConfigProfileError` from P21 is unchanged.
+
+### 4.6 Help text and CLI strings audit
+
+Every literal string in code that names a config path is audited and updated:
+
+- `src/thoth/help.py` — `thoth help config`, init help, etc.
+- `src/thoth/cli_subcommands/config.py` — leaf help text.
+- `src/thoth/errors.py` — error formatting.
+- Any other `*.py` file containing `config.toml`, `thoth.toml`, or `.thoth/`.
+
+## 5. Documentation
+
+P21c updates:
+
+- `README.md` — config section, install/setup walkthrough, migration note for users on legacy filenames.
+- `manual_testing_instructions.md` — every smoke test that references a config path.
+- `CLAUDE.md` and `AGENTS.md` — audited and updated if either names a config file.
+- P21 spec/plan (`docs/superpowers/specs/2026-04-28-p21-configuration-profiles-design.md`, `docs/superpowers/plans/2026-04-28-p21-configuration-profiles.md`) — updated to canonical names *or* annotated with a "see P21c" pointer; choice depends on §7 sequencing.
+- P21b spec/plan — same treatment.
+- Any `planning/` doc that names config paths.
+
+The migration note in README is short:
+
+> **Migrating from earlier Thoth versions.** Rename `~/.config/thoth/config.toml` → `~/.config/thoth/thoth.config.toml`, `./thoth.toml` → `./thoth.config.toml` (or `./.thoth.config.toml`), and `./.thoth/config.toml` → `./.thoth.config.toml`. Thoth no longer reads the old filenames.
+
+## 6. Out of Scope
+
+- A `thoth config migrate` CLI command that renames files in place. (Could be a future project if the rename instruction proves insufficient.)
+- A "deprecation window" or fallback read of legacy filenames. Decided against; clean break.
+- Changing the file format (still TOML).
+- Changing the *structure* inside the file.
+- Changing the project marker semantics (presence of either canonical project path still means "this is a Thoth project").
+- Adding a `THOTH_CONFIG_FILENAME` env var to override the filename.
+- Picking precedence between `./thoth.config.toml` and `./.thoth.config.toml`. There is no precedence; both present → error.
+- A directory-form project config (e.g. `./.thoth/thoth.config.toml`). The `.thoth/` directory pattern is retired for config purposes.
+
+## 7. Sequencing
+
+P21c interacts with P21 and P21b because both reference the legacy filenames in specs, plans, tests, and error messages. Three viable orderings:
+
+1. **P21c → P21 → P21b** *(preferred)*. P21c lands first while P21 is still in planning; P21's spec/plan/tests are written against the new names from the start.
+2. **P21 → P21c → P21b**. P21 ships with legacy names; P21c follows and sweeps P21's tests/strings; P21b is then written against the new names. Cost: extra churn.
+3. **P21 → P21b → P21c**. Both ship on legacy names; P21c does one big rename sweep. Cost: largest sweep.
+
+Option 1 is recommended unless P21 is already mid-implementation when P21c is approved.
+
+## 8. Acceptance Criteria
+
+- `thoth.config.toml` is read from all three canonical locations: user XDG, project root, and project dotfile form.
+- Legacy filenames (`config.toml` in user dir, `thoth.toml`, `.thoth/config.toml`) are **not** read.
+- When no canonical config is found and a legacy file exists at one of the legacy paths, the "config not found" error names the detected legacy file(s) and the rename target.
+- When both `./thoth.config.toml` and `./.thoth.config.toml` exist in the project root, Thoth raises `ConfigAmbiguousError` and asks the user to delete one. No precedence is applied.
+- `thoth init` writes `./thoth.config.toml`. The dotfile-form flag writes `./.thoth.config.toml`. `thoth init --user` writes `$XDG_CONFIG_HOME/thoth/thoth.config.toml`. `--user` and the dotfile-form flag are mutually exclusive.
+- README, manual_testing_instructions, help text, error messages, and P21/P21b spec/plan docs all reference `thoth.config.toml`.
+- Successful config loads do **not** call the legacy detection helper (regression guard for inadvertent fallback).
+- `git diff --check`, `just check`, `./thoth_test -r --skip-interactive -q`, `just test-lint`, `just test-typecheck` all pass.
+
+## 9. Open Questions
+
+Small items for the plan, not blockers for approval:
+
+1. **Dotfile-form `init` flag spelling** — `--hidden`, `--dotfile`, or `--dot`? Recommendation: `--hidden` (most discoverable in `--help`).
+2. **`init --user --force`** semantics — confirm `--force` overwrite applies to the user-tier file too, not just the project file.
+3. **Test fixture file layout** — existing tests use `tmp_path` heavily; confirm the new ambiguity test can reuse those fixtures without restructuring.

--- a/manual_testing_instructions.md
+++ b/manual_testing_instructions.md
@@ -247,3 +247,27 @@ Expected:
 - Two resume hints print on Ctrl-C (the older Rich-formatted line + the new "Resume later:"). Functional but redundant; tracked as a follow-up nit.
 - `thoth providers help` (without subcommand) currently shows the legacy provider help — examples there still mention `--list` / `--models` flags rather than the new subcommands. Will be cleaned up when the deprecation shim is removed in N+1.
 - `--pick-model` over a non-TTY input (e.g. CI without `echo N |`) will hang on the prompt. Pipe a number in or skip the flag.
+
+---
+
+## Configuration Profiles (P21)
+
+Hand-edit `~/.config/thoth/config.toml` first to add:
+
+```toml
+[profiles.fast.general]
+default_mode = "thinking"
+
+[general]
+default_profile = "fast"
+```
+
+Then run:
+
+```bash
+thoth config get general.default_mode                      # expect "thinking" (from profile)
+THOTH_PROFILE=fast thoth config get general.default_mode   # expect "thinking"
+thoth --profile missing config get general.default_mode    # expect ConfigProfileError naming '--profile flag'
+thoth config get general.default_profile                   # expect "fast" (persisted)
+thoth --profile bar config get general.default_profile     # expect "fast" (NOT mutated by --profile)
+```

--- a/manual_testing_instructions.md
+++ b/manual_testing_instructions.md
@@ -271,3 +271,23 @@ thoth --profile missing config get general.default_mode    # expect ConfigProfil
 thoth config get general.default_profile                   # expect "fast" (persisted)
 thoth --profile bar config get general.default_profile     # expect "fast" (NOT mutated by --profile)
 ```
+
+### Shipped profile examples
+
+`thoth init` writes these example profiles into your config so you can try them immediately:
+
+```bash
+thoth --profile daily "what should I focus on today?"      # default_mode=thinking, default_project=daily-notes
+thoth --profile openai_deep "compare vector databases"     # deep_research, providers=["openai"]
+thoth --profile all_deep "compare vector databases"        # deep_research, parallel openai+perplexity
+thoth --profile deep_research "literature review of X"     # deep_research + a worked prompt_prefix
+```
+
+### Verifying `prompt_prefix` is applied
+
+```bash
+# With the shipped `deep_research` profile, the prompt that reaches the LLM is
+# prepended with: "Be thorough. Cite primary sources. Include counter-arguments."
+thoth --profile deep_research --verbose "research vector dbs"
+# Look for the assembled prompt in the verbose output.
+```

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -146,7 +146,22 @@ def _prompt_max_bytes() -> int:
     return max_bytes
 
 
-def _resolve_mode_and_prompt(args: list[str], opts: dict) -> tuple[str, str | None]:
+def _config_default_mode(config: ConfigManager) -> str:
+    raw = config.get("general.default_mode", "default")
+    return str(raw) if raw else "default"
+
+
+def _config_default_project(config: ConfigManager) -> str | None:
+    raw = config.get("general.default_project")
+    return str(raw) if raw else None
+
+
+def _resolve_mode_and_prompt(
+    args: list[str],
+    opts: dict,
+    *,
+    default_mode: str = "default",
+) -> tuple[str, str | None]:
     mode_opt = opts.get("mode_opt")
     prompt_opt = opts.get("prompt_opt")
     prompt_file = opts.get("prompt_file")
@@ -165,10 +180,10 @@ def _resolve_mode_and_prompt(args: list[str], opts: dict) -> tuple[str, str | No
             console.print(f"[red]Error:[/red] Unknown mode: {first}")
             sys.exit(1)
         else:
-            mode = mode_opt or "default"
+            mode = mode_opt or default_mode
             prompt = " ".join(args)
     else:
-        mode = mode_opt or "default"
+        mode = mode_opt or default_mode
         prompt = prompt_opt
 
     if prompt_file:
@@ -357,7 +372,12 @@ def _dispatch_click_fallback(
     _apply_config_path(opts.get("config_path"))
 
     if opts.get("interactive"):
-        mode, prompt = _resolve_mode_and_prompt(args, opts)
+        config = _thoth_config.get_config(profile=opts.get("profile"))
+        mode, prompt = _resolve_mode_and_prompt(
+            args,
+            opts,
+            default_mode=_config_default_mode(config),
+        )
         _enter_interactive_from_options(mode=mode, prompt=prompt, opts=opts)
         return
 
@@ -365,14 +385,22 @@ def _dispatch_click_fallback(
         click.echo(ctx.get_help())
         ctx.exit(0)
 
-    mode, prompt = _resolve_mode_and_prompt(args, opts)
+    config = _thoth_config.get_config(profile=opts.get("profile"))
+    mode, prompt = _resolve_mode_and_prompt(
+        args,
+        opts,
+        default_mode=_config_default_mode(config),
+    )
     if not prompt:
         raise click.BadParameter("Prompt cannot be empty")
 
     model_override = None
     if opts.get("pick_model"):
-        config = _thoth_config.get_config()
         model_override = _pick_model_override(mode, config)
+
+    project = opts.get("project")
+    if project is None:
+        project = _config_default_project(config)
 
     cli_api_keys = {
         "openai": opts.get("api_key_openai"),
@@ -383,7 +411,7 @@ def _dispatch_click_fallback(
         mode=mode,
         prompt=prompt,
         async_mode=bool(opts.get("async_mode")),
-        project=opts.get("project"),
+        project=project,
         output_dir=opts.get("output_dir"),
         provider=opts.get("provider"),
         input_file=opts.get("input_file"),
@@ -398,6 +426,7 @@ def _dispatch_click_fallback(
         ctx_obj=None,
         out=tuple(opts.get("out") or ()),
         append=bool(opts.get("append")),
+        profile=opts.get("profile"),
     )
 
 
@@ -439,6 +468,7 @@ def _run_research_default(
     ctx_obj=None,
     out: tuple[str, ...] = (),
     append: bool = False,
+    profile: str | None = None,
 ) -> None:
     """Execute a research run with the given mode and prompt.
 
@@ -469,6 +499,7 @@ def _run_research_default(
         model_override=model_override,
         out_specs=tuple(out or ()),
         append=append,
+        profile=profile,
     )
     _run_maybe_async(_result)
 

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -111,6 +111,7 @@ def _version_conflicts(ctx: click.Context, opts: dict) -> list[str]:
         "api_key_perplexity": "--api-key-perplexity",
         "api_key_mock": "--api-key-mock",
         "config_path": "--config",
+        "profile": "--profile",
         "combined": "--combined",
         "quiet": "--quiet",
         "no_metadata": "--no-metadata",
@@ -197,6 +198,7 @@ def _extract_fallback_options(args: list[str], opts: dict) -> tuple[list[str], d
         "--api-key-mock": "api_key_mock",
         "--config": "config_path",
         "-c": "config_path",
+        "--profile": "profile",
         "--timeout": "timeout",
         "-T": "timeout",
         "--out": "out",
@@ -496,6 +498,7 @@ def cli(
     api_key_perplexity,
     api_key_mock,
     config_path,
+    profile,
     combined,
     quiet,
     no_metadata,
@@ -532,6 +535,7 @@ def cli(
     ctx.obj["api_key_perplexity"] = api_key_perplexity
     ctx.obj["api_key_mock"] = api_key_mock
     ctx.obj["config_path"] = config_path
+    ctx.obj["profile"] = profile
     ctx.obj["combined"] = combined
     ctx.obj["quiet"] = quiet
     ctx.obj["no_metadata"] = no_metadata

--- a/src/thoth/cli.py
+++ b/src/thoth/cli.py
@@ -356,6 +356,7 @@ def _enter_interactive_from_options(
             quiet=bool(opts.get("quiet")),
             no_metadata=bool(opts.get("no_metadata")),
             timeout=opts.get("timeout"),
+            profile=opts.get("profile"),
         )
     )
 

--- a/src/thoth/cli_subcommands/_option_policy.py
+++ b/src/thoth/cli_subcommands/_option_policy.py
@@ -29,6 +29,7 @@ ROOT_OPTION_LABELS: dict[str, str] = {
     "api_key_perplexity": "--api-key-perplexity",
     "api_key_mock": "--api-key-mock",
     "config_path": "--config",
+    "profile": "--profile",
     "combined": "--combined",
     "quiet": "--quiet",
     "no_metadata": "--no-metadata",
@@ -44,7 +45,7 @@ ROOT_OPTION_ORDER: tuple[str, ...] = tuple(ROOT_OPTION_LABELS)
 
 # The smallest cross-command default: a custom config file can be honored by
 # command handlers that load configuration. Other inherited options must opt in.
-DEFAULT_HONOR: frozenset[str] = frozenset({"config_path"})
+DEFAULT_HONOR: frozenset[str] = frozenset({"config_path", "profile"})
 NO_INHERITED_OPTIONS: frozenset[str] = frozenset()
 
 

--- a/src/thoth/cli_subcommands/_options.py
+++ b/src/thoth/cli_subcommands/_options.py
@@ -69,6 +69,7 @@ _RESEARCH_OPTIONS: list[tuple[tuple, dict]] = [
         {"help": "API key for Mock provider (not recommended; prefer env vars)"},
     ),
     (("--config", "-c", "config_path"), {"help": "Path to custom config file"}),
+    (("--profile", "profile"), {"help": "Configuration profile to apply"}),
     (
         ("--combined",),
         {"is_flag": True, "help": "Generate combined report from multiple providers"},

--- a/src/thoth/cli_subcommands/ask.py
+++ b/src/thoth/cli_subcommands/ask.py
@@ -63,6 +63,7 @@ def ask(
     api_key_perplexity: str | None,
     api_key_mock: str | None,
     config_path: str | None,
+    profile: str | None,
     combined: bool,
     quiet: bool,
     no_metadata: bool,

--- a/src/thoth/cli_subcommands/ask.py
+++ b/src/thoth/cli_subcommands/ask.py
@@ -123,9 +123,7 @@ def ask(
     # Subcommand-level option wins over group-level (already true via Click)
     inherited = ctx.obj or {}
 
-    effective_mode = pick_value(mode_opt, ctx, "mode_opt") or "default"
     effective_provider = pick_value(provider, ctx, "provider")
-    effective_project = pick_value(project, ctx, "project")
     effective_output_dir = pick_value(output_dir, ctx, "output_dir")
     effective_input_file = pick_value(input_file, ctx, "input_file")
     effective_async = bool(async_mode or inherited.get("async_mode"))
@@ -136,6 +134,7 @@ def ask(
     effective_no_metadata = bool(no_metadata or inherited.get("no_metadata"))
     effective_timeout = pick_value(timeout, ctx, "timeout")
     effective_config = pick_value(config_path, ctx, "config_path")
+    effective_profile = pick_value(profile, ctx, "profile")
     root_api_keys = inherited_api_keys(ctx)
     cli_api_keys = {
         "openai": api_key_openai or root_api_keys["openai"],
@@ -146,12 +145,20 @@ def ask(
     # Local import: avoids cli.py → cli_subcommands → cli.py circular at module load.
     from thoth.cli import (
         _apply_config_path,
+        _config_default_mode,
+        _config_default_project,
         _prompt_max_bytes,
         _read_prompt_input,
         _run_research_default,
     )
+    from thoth.config import get_config
 
     _apply_config_path(effective_config)
+    config = get_config(profile=effective_profile)
+    effective_mode = pick_value(mode_opt, ctx, "mode_opt") or _config_default_mode(config)
+    effective_project = pick_value(project, ctx, "project")
+    if effective_project is None:
+        effective_project = _config_default_project(config)
 
     if effective_prompt_file:
         effective_prompt = _read_prompt_input(str(effective_prompt_file), _prompt_max_bytes())
@@ -202,6 +209,7 @@ def ask(
                     no_metadata=effective_no_metadata,
                     timeout_override=effective_timeout,
                     model_override=None,
+                    profile=effective_profile,
                 )
         except SystemExit as exc:
             if exc.code not in (None, 0):
@@ -255,6 +263,7 @@ def ask(
         model_override=None,
         out=out,
         append=append,
+        profile=effective_profile,
     )
 
 

--- a/src/thoth/cli_subcommands/config.py
+++ b/src/thoth/cli_subcommands/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from typing import NoReturn
 
 import click
 
@@ -54,16 +53,6 @@ def _dispatch(
     sys.exit(rc)
 
 
-def _emit_config_profile_error(exc: Exception) -> NoReturn:
-    from thoth.errors import ConfigProfileError
-    from thoth.json_output import emit_error
-
-    if not isinstance(exc, ConfigProfileError):
-        raise exc
-    details = {"suggestion": exc.suggestion} if exc.suggestion else None
-    emit_error("CONFIG_PROFILE_ERROR", exc.message, details, exit_code=exc.exit_code)
-
-
 @config.command(name="get")
 @click.argument("key", shell_complete=_config_keys_completer)
 @click.option(
@@ -99,6 +88,7 @@ def config_get(
 
     if as_json:
         from thoth.config_cmd import get_config_get_data
+        from thoth.errors import ConfigProfileError
         from thoth.json_output import emit_error, emit_json
 
         profile = inherited_value(ctx, "profile")
@@ -111,8 +101,9 @@ def config_get(
                 config_path=config_path,
                 profile=profile,
             )
-        except Exception as exc:  # noqa: BLE001 - converted selectively below
-            _emit_config_profile_error(exc)
+        except ConfigProfileError as exc:
+            details = {"suggestion": exc.suggestion} if exc.suggestion else None
+            emit_error("CONFIG_PROFILE_ERROR", exc.message, details, exit_code=exc.exit_code)
         if data.get("error") == "INVALID_LAYER":
             emit_error(
                 "INVALID_LAYER",
@@ -222,6 +213,7 @@ def config_list(ctx: click.Context, args: tuple[str, ...], as_json: bool) -> Non
     """List all configuration values. Supports --json."""
     if as_json:
         from thoth.config_cmd import get_config_list_data
+        from thoth.errors import ConfigProfileError
         from thoth.json_output import emit_error, emit_json
 
         validate_inherited_options(ctx, "config list", DEFAULT_HONOR)
@@ -256,8 +248,9 @@ def config_list(ctx: click.Context, args: tuple[str, ...], as_json: bool) -> Non
                 config_path=config_path,
                 profile=profile,
             )
-        except Exception as exc:  # noqa: BLE001 - converted selectively below
-            _emit_config_profile_error(exc)
+        except ConfigProfileError as exc:
+            details = {"suggestion": exc.suggestion} if exc.suggestion else None
+            emit_error("CONFIG_PROFILE_ERROR", exc.message, details, exit_code=exc.exit_code)
         if data.get("error") == "INVALID_LAYER":
             emit_error(
                 "INVALID_LAYER",

--- a/src/thoth/cli_subcommands/config.py
+++ b/src/thoth/cli_subcommands/config.py
@@ -38,13 +38,18 @@ def _dispatch(
     honored_options=DEFAULT_HONOR,
 ) -> None:
     from thoth.config_cmd import config_command
+    from thoth.errors import ConfigProfileError
 
     validate_inherited_options(ctx, f"config {op}", honored_options)
     config_path = inherited_value(ctx, "config_path")
-    if config_path is None:
-        rc = config_command(op, list(args))
-    else:
-        rc = config_command(op, list(args), config_path=config_path)
+    profile = inherited_value(ctx, "profile")
+    try:
+        rc = config_command(op, list(args), config_path=config_path, profile=profile)
+    except ConfigProfileError as exc:
+        click.echo(f"Error: {exc.message}")
+        if exc.suggestion:
+            click.echo(f"Suggestion: {exc.suggestion}")
+        sys.exit(exc.exit_code)
     sys.exit(rc)
 
 
@@ -85,8 +90,14 @@ def config_get(
         from thoth.config_cmd import get_config_get_data
         from thoth.json_output import emit_error, emit_json
 
+        profile = inherited_value(ctx, "profile")
         data = get_config_get_data(
-            key, layer=layer, raw=raw, show_secrets=show_secrets, config_path=config_path
+            key,
+            layer=layer,
+            raw=raw,
+            show_secrets=show_secrets,
+            config_path=config_path,
+            profile=profile,
         )
         if data.get("error") == "INVALID_LAYER":
             emit_error(
@@ -222,11 +233,13 @@ def config_list(ctx: click.Context, args: tuple[str, ...], as_json: bool) -> Non
                 i += 1
             else:
                 emit_error("USAGE_ERROR", f"unknown arg: {a}", exit_code=2)
+        profile = inherited_value(ctx, "profile")
         data = get_config_list_data(
             layer=layer,
             keys_only=keys_only,
             show_secrets=show_secrets,
             config_path=config_path,
+            profile=profile,
         )
         if data.get("error") == "INVALID_LAYER":
             emit_error(

--- a/src/thoth/cli_subcommands/config.py
+++ b/src/thoth/cli_subcommands/config.py
@@ -15,7 +15,7 @@ from thoth.cli_subcommands._option_policy import (
 from thoth.completion.sources import config_keys as _config_keys_completer
 
 _PASSTHROUGH_CONTEXT = {"ignore_unknown_options": True, "allow_extra_args": True}
-_VALID_LAYERS = ("defaults", "user", "project", "env", "cli")
+_VALID_LAYERS = ("defaults", "user", "project", "profile", "env", "cli")
 
 
 @click.group(name="config", invoke_without_command=True)

--- a/src/thoth/cli_subcommands/config.py
+++ b/src/thoth/cli_subcommands/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from typing import NoReturn
 
 import click
 
@@ -53,6 +54,16 @@ def _dispatch(
     sys.exit(rc)
 
 
+def _emit_config_profile_error(exc: Exception) -> NoReturn:
+    from thoth.errors import ConfigProfileError
+    from thoth.json_output import emit_error
+
+    if not isinstance(exc, ConfigProfileError):
+        raise exc
+    details = {"suggestion": exc.suggestion} if exc.suggestion else None
+    emit_error("CONFIG_PROFILE_ERROR", exc.message, details, exit_code=exc.exit_code)
+
+
 @config.command(name="get")
 @click.argument("key", shell_complete=_config_keys_completer)
 @click.option(
@@ -91,14 +102,17 @@ def config_get(
         from thoth.json_output import emit_error, emit_json
 
         profile = inherited_value(ctx, "profile")
-        data = get_config_get_data(
-            key,
-            layer=layer,
-            raw=raw,
-            show_secrets=show_secrets,
-            config_path=config_path,
-            profile=profile,
-        )
+        try:
+            data = get_config_get_data(
+                key,
+                layer=layer,
+                raw=raw,
+                show_secrets=show_secrets,
+                config_path=config_path,
+                profile=profile,
+            )
+        except Exception as exc:  # noqa: BLE001 - converted selectively below
+            _emit_config_profile_error(exc)
         if data.get("error") == "INVALID_LAYER":
             emit_error(
                 "INVALID_LAYER",
@@ -234,13 +248,16 @@ def config_list(ctx: click.Context, args: tuple[str, ...], as_json: bool) -> Non
             else:
                 emit_error("USAGE_ERROR", f"unknown arg: {a}", exit_code=2)
         profile = inherited_value(ctx, "profile")
-        data = get_config_list_data(
-            layer=layer,
-            keys_only=keys_only,
-            show_secrets=show_secrets,
-            config_path=config_path,
-            profile=profile,
-        )
+        try:
+            data = get_config_list_data(
+                layer=layer,
+                keys_only=keys_only,
+                show_secrets=show_secrets,
+                config_path=config_path,
+                profile=profile,
+            )
+        except Exception as exc:  # noqa: BLE001 - converted selectively below
+            _emit_config_profile_error(exc)
         if data.get("error") == "INVALID_LAYER":
             emit_error(
                 "INVALID_LAYER",

--- a/src/thoth/cli_subcommands/init.py
+++ b/src/thoth/cli_subcommands/init.py
@@ -6,6 +6,8 @@ from the pre-P16 imperative dispatch (cli.py:298-300).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from thoth.cli_subcommands._option_policy import DEFAULT_HONOR, validate_inherited_options
@@ -38,8 +40,10 @@ def init(ctx: click.Context, as_json: bool, non_interactive: bool) -> None:
         emit_json(get_init_data(non_interactive=True, config_path=config_path))
 
     profile = ctx.obj.get("profile") if ctx.obj else None
-    config_manager = ConfigManager()
-    cli_args: dict[str, object] = {"config_path": config_path}
+    config_manager = ConfigManager(
+        Path(config_path).expanduser().resolve() if config_path else None
+    )
+    cli_args: dict[str, object] = {}
     if profile:
         cli_args["_profile"] = profile
     config_manager.load_all_layers(cli_args)

--- a/src/thoth/cli_subcommands/init.py
+++ b/src/thoth/cli_subcommands/init.py
@@ -37,7 +37,11 @@ def init(ctx: click.Context, as_json: bool, non_interactive: bool) -> None:
             )
         emit_json(get_init_data(non_interactive=True, config_path=config_path))
 
+    profile = ctx.obj.get("profile") if ctx.obj else None
     config_manager = ConfigManager()
-    config_manager.load_all_layers({"config_path": config_path})
+    cli_args: dict[str, object] = {"config_path": config_path}
+    if profile:
+        cli_args["_profile"] = profile
+    config_manager.load_all_layers(cli_args)
     handler = CommandHandler(config_manager)
     handler.init_command(config_path=config_path)

--- a/src/thoth/cli_subcommands/list_cmd.py
+++ b/src/thoth/cli_subcommands/list_cmd.py
@@ -22,8 +22,12 @@ def list_cmd(ctx: click.Context, show_all: bool, as_json: bool) -> None:
     validate_inherited_options(ctx, "list", DEFAULT_HONOR)
 
     config_path = ctx.obj.get("config_path") if ctx.obj else None
+    profile = ctx.obj.get("profile") if ctx.obj else None
     config_manager = ConfigManager()
-    config_manager.load_all_layers({"config_path": config_path})
+    cli_args: dict[str, object] = {"config_path": config_path}
+    if profile:
+        cli_args["_profile"] = profile
+    config_manager.load_all_layers(cli_args)
 
     if as_json:
         emit_json(asyncio.run(get_list_data(show_all=show_all)))

--- a/src/thoth/cli_subcommands/list_cmd.py
+++ b/src/thoth/cli_subcommands/list_cmd.py
@@ -4,6 +4,7 @@ keyword shadow; the registered command name is "list"."""
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import click
 
@@ -23,8 +24,10 @@ def list_cmd(ctx: click.Context, show_all: bool, as_json: bool) -> None:
 
     config_path = ctx.obj.get("config_path") if ctx.obj else None
     profile = ctx.obj.get("profile") if ctx.obj else None
-    config_manager = ConfigManager()
-    cli_args: dict[str, object] = {"config_path": config_path}
+    config_manager = ConfigManager(
+        Path(config_path).expanduser().resolve() if config_path else None
+    )
+    cli_args: dict[str, object] = {}
     if profile:
         cli_args["_profile"] = profile
     config_manager.load_all_layers(cli_args)

--- a/src/thoth/cli_subcommands/providers.py
+++ b/src/thoth/cli_subcommands/providers.py
@@ -109,14 +109,14 @@ def providers_list_cmd(ctx: click.Context, filter_provider: str | None, as_json:
     validate_inherited_options(ctx, "providers list", _PROVIDERS_LIST_HONOR)
 
     from thoth import commands as _commands
-    from thoth.config import ConfigManager
+    from thoth.config import get_config
     from thoth.json_output import emit_error, emit_json
 
     effective_provider = pick_value(filter_provider, ctx, "provider")
+    profile = inherited_value(ctx, "profile")
 
     if as_json:
-        config_manager = ConfigManager()
-        config_manager.load_all_layers({})
+        config_manager = get_config(profile=profile)
         data = _commands.get_providers_list_data(config_manager, filter_provider=effective_provider)
         if data.get("unknown"):
             emit_error(
@@ -135,6 +135,7 @@ def providers_list_cmd(ctx: click.Context, filter_provider: str | None, as_json:
                     show_list=True,
                     filter_provider=effective_provider,
                     cli_api_keys=keys,
+                    profile=profile,
                 )
             )
         )
@@ -143,6 +144,7 @@ def providers_list_cmd(ctx: click.Context, filter_provider: str | None, as_json:
             _commands.providers_command(
                 show_list=True,
                 filter_provider=effective_provider,
+                profile=profile,
             )
         )
     )
@@ -178,14 +180,14 @@ def providers_models_cmd(
             param_hint="--refresh-cache / --no-cache",
         )
     from thoth import commands as _commands
-    from thoth.config import ConfigManager
+    from thoth.config import get_config
     from thoth.json_output import emit_json
 
     effective_provider = pick_value(filter_provider, ctx, "provider")
+    profile = inherited_value(ctx, "profile")
 
     if as_json:
-        config_manager = ConfigManager()
-        config_manager.load_all_layers({})
+        config_manager = get_config(profile=profile)
         emit_json(
             _commands.get_providers_models_data(config_manager, filter_provider=effective_provider)
         )
@@ -202,6 +204,7 @@ def providers_models_cmd(
                     no_cache=no_cache,
                     cli_api_keys=keys,
                     timeout_override=timeout,
+                    profile=profile,
                 )
             )
         )
@@ -214,6 +217,7 @@ def providers_models_cmd(
                     refresh_cache=refresh_cache,
                     no_cache=no_cache,
                     cli_api_keys=keys,
+                    profile=profile,
                 )
             )
         )
@@ -224,6 +228,7 @@ def providers_models_cmd(
                 filter_provider=effective_provider,
                 refresh_cache=refresh_cache,
                 no_cache=no_cache,
+                profile=profile,
             )
         )
     )
@@ -245,14 +250,14 @@ def providers_check_cmd(ctx: click.Context, filter_provider: str | None, as_json
     validate_inherited_options(ctx, "providers check", _PROVIDERS_CHECK_HONOR)
 
     from thoth import commands as _commands
-    from thoth.config import ConfigManager
+    from thoth.config import get_config
     from thoth.json_output import emit_json
 
     effective_provider = pick_value(filter_provider, ctx, "provider")
+    profile = inherited_value(ctx, "profile")
 
     if as_json:
-        config_manager = ConfigManager()
-        config_manager.load_all_layers({})
+        config_manager = get_config(profile=profile)
         # Honor `--provider` by narrowing the providers view before checking.
         if effective_provider is not None:
             full = config_manager.data["providers"]
@@ -269,6 +274,7 @@ def providers_check_cmd(ctx: click.Context, filter_provider: str | None, as_json
                     show_keys=True,
                     filter_provider=effective_provider,
                     cli_api_keys=keys,
+                    profile=profile,
                 )
             )
         )
@@ -277,6 +283,7 @@ def providers_check_cmd(ctx: click.Context, filter_provider: str | None, as_json
             _commands.providers_command(
                 show_keys=True,
                 filter_provider=effective_provider,
+                profile=profile,
             )
         )
     )

--- a/src/thoth/cli_subcommands/status.py
+++ b/src/thoth/cli_subcommands/status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import click
 
@@ -50,8 +51,10 @@ def status(ctx: click.Context, operation_id: str | None, as_json: bool) -> None:
     # Default Rich path
     config_path = ctx.obj.get("config_path") if ctx.obj else None
     profile = ctx.obj.get("profile") if ctx.obj else None
-    config_manager = ConfigManager()
-    cli_args: dict[str, object] = {"config_path": config_path}
+    config_manager = ConfigManager(
+        Path(config_path).expanduser().resolve() if config_path else None
+    )
+    cli_args: dict[str, object] = {}
     if profile:
         cli_args["_profile"] = profile
     config_manager.load_all_layers(cli_args)

--- a/src/thoth/cli_subcommands/status.py
+++ b/src/thoth/cli_subcommands/status.py
@@ -49,7 +49,11 @@ def status(ctx: click.Context, operation_id: str | None, as_json: bool) -> None:
 
     # Default Rich path
     config_path = ctx.obj.get("config_path") if ctx.obj else None
+    profile = ctx.obj.get("profile") if ctx.obj else None
     config_manager = ConfigManager()
-    config_manager.load_all_layers({"config_path": config_path})
+    cli_args: dict[str, object] = {"config_path": config_path}
+    if profile:
+        cli_args["_profile"] = profile
+    config_manager.load_all_layers(cli_args)
     handler = CommandHandler(config_manager)
     handler.status_command(operation_id=operation_id)

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -39,6 +39,11 @@ def _build_profile_section(body: dict[str, Any]) -> tomlkit.items.Table:
     `body` is a flat dict whose keys are TOML section names under the profile
     (e.g., ``"general"``, ``"modes.deep_research"``) and whose values are
     dicts of leaf keys.
+
+    Sibling sections sharing a prefix (e.g., ``"modes.deep_research"`` and
+    ``"modes.thinking"``) are merged under the same intermediate table; the
+    helper reuses an existing intermediate when present rather than
+    overwriting it (C14).
     """
     profile_table = tomlkit.table()
     for section_path, leaves in body.items():
@@ -46,12 +51,18 @@ def _build_profile_section(body: dict[str, Any]) -> tomlkit.items.Table:
         for key, value in leaves.items():
             section[key] = value
         # Resolve nested paths like "modes.deep_research" by walking parts.
+        # Reuse an existing intermediate table when it's already present
+        # (so multiple sibling sections under the same prefix coexist).
         parts = section_path.split(".")
         cursor: Any = profile_table
         for part in parts[:-1]:
-            child = tomlkit.table()
-            cursor[part] = child
-            cursor = child
+            existing = cursor.get(part) if hasattr(cursor, "get") else None
+            if hasattr(existing, "keys"):
+                cursor = existing
+            else:
+                child = tomlkit.table()
+                cursor[part] = child
+                cursor = child
         cursor[parts[-1]] = section
     return profile_table
 

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -64,9 +64,7 @@ def _build_starter_profiles() -> tomlkit.items.Table:
         "daily",
         {"general": {"default_mode": "thinking", "default_project": "daily-notes"}},
     )
-    profiles["quick"] = _build_profile_section(
-        "quick", {"general": {"default_mode": "thinking"}}
-    )
+    profiles["quick"] = _build_profile_section("quick", {"general": {"default_mode": "thinking"}})
     profiles["openai_deep"] = _build_profile_section(
         "openai_deep",
         {
@@ -98,9 +96,7 @@ def _build_starter_profiles() -> tomlkit.items.Table:
             "modes.deep_research": {
                 "providers": ["openai", "perplexity"],
                 "parallel": True,
-                "prompt_prefix": (
-                    "Be thorough. Cite primary sources. Include counter-arguments."
-                ),
+                "prompt_prefix": ("Be thorough. Cite primary sources. Include counter-arguments."),
             },
         },
     )
@@ -151,21 +147,9 @@ def _build_starter_document() -> tomlkit.TOMLDocument:
     doc["providers"] = providers
 
     doc.add(tomlkit.nl())
-    doc.add(
-        tomlkit.comment(
-            "Configuration profiles (P21). Activate with --profile NAME,"
-        )
-    )
-    doc.add(
-        tomlkit.comment(
-            "THOTH_PROFILE=NAME, or general.default_profile."
-        )
-    )
-    doc.add(
-        tomlkit.comment(
-            "Profile values REPLACE top-level values when the profile is active."
-        )
-    )
+    doc.add(tomlkit.comment("Configuration profiles (P21). Activate with --profile NAME,"))
+    doc.add(tomlkit.comment("THOTH_PROFILE=NAME, or general.default_profile."))
+    doc.add(tomlkit.comment("Profile values REPLACE top-level values when the profile is active."))
     doc["profiles"] = _build_starter_profiles()
     return doc
 

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import tomlkit
+import tomlkit.items
 from rich import box
 from rich.console import Console
 from rich.table import Table
@@ -31,53 +33,141 @@ from thoth.run import run_research
 console = Console()
 
 
-def _starter_profiles_block() -> str:
-    """TOML block of example `[profiles.*]` sections shipped by `thoth init`.
+def _build_profile_section(name: str, body: dict[str, Any]) -> tomlkit.items.Table:
+    """Build a `[profiles.<name>]` table containing nested sub-tables.
 
-    Six worked examples that double as on-ramp documentation for the
-    `--profile NAME` plumbing and the `prompt_prefix` hierarchy. Users are
-    expected to customize/remove these.
+    `body` is a flat dict whose keys are TOML section names under the profile
+    (e.g., ``"general"``, ``"modes.deep_research"``) and whose values are
+    dicts of leaf keys.
     """
-    return (
-        "# --- Configuration profiles (P21) -----------------------------------\n"
-        "# Activate with `thoth --profile NAME ...`, `THOTH_PROFILE=NAME`,\n"
-        "# or set `general.default_profile = \"NAME\"` above.\n"
-        "# Profile values REPLACE top-level values when the profile is active.\n"
-        "\n"
-        "[profiles.daily.general]\n"
-        'default_mode = "thinking"\n'
-        'default_project = "daily-notes"\n'
-        "\n"
-        "[profiles.quick.general]\n"
-        'default_mode = "thinking"\n'
-        "\n"
-        "[profiles.openai_deep.general]\n"
-        'default_mode = "deep_research"\n'
-        "[profiles.openai_deep.modes.deep_research]\n"
-        'providers = ["openai"]\n'
-        "parallel = false\n"
-        "\n"
-        "[profiles.all_deep.general]\n"
-        'default_mode = "deep_research"\n'
-        "[profiles.all_deep.modes.deep_research]\n"
-        'providers = ["openai", "perplexity"]\n'
-        "parallel = true\n"
-        "\n"
-        "[profiles.interactive.general]\n"
-        'default_mode = "interactive"\n'
-        "\n"
-        "# Worked example of the `prompt_prefix` hierarchy. The prefix below\n"
-        "# is prepended to the user's prompt when this profile is active and\n"
-        "# any deep_research run starts. Order: profile.modes.M > profile >\n"
-        "# modes.M > general (more-specific replaces less-specific).\n"
-        "[profiles.deep_research.general]\n"
-        'default_mode = "deep_research"\n'
-        'prompt_prefix = "Be thorough. Cite primary sources where possible."\n'
-        "[profiles.deep_research.modes.deep_research]\n"
-        'providers = ["openai", "perplexity"]\n'
-        "parallel = true\n"
-        'prompt_prefix = "Be thorough. Cite primary sources. Include counter-arguments."\n'
+    profile_table = tomlkit.table()
+    for section_path, leaves in body.items():
+        section = tomlkit.table()
+        for key, value in leaves.items():
+            section[key] = value
+        # Resolve nested paths like "modes.deep_research" by walking parts.
+        parts = section_path.split(".")
+        cursor: Any = profile_table
+        for part in parts[:-1]:
+            child = tomlkit.table()
+            cursor[part] = child
+            cursor = child
+        cursor[parts[-1]] = section
+    return profile_table
+
+
+def _build_starter_profiles() -> tomlkit.items.Table:
+    """Build the `[profiles]` super-table shipped by `thoth init`."""
+    profiles = tomlkit.table()
+
+    profiles["daily"] = _build_profile_section(
+        "daily",
+        {"general": {"default_mode": "thinking", "default_project": "daily-notes"}},
     )
+    profiles["quick"] = _build_profile_section(
+        "quick", {"general": {"default_mode": "thinking"}}
+    )
+    profiles["openai_deep"] = _build_profile_section(
+        "openai_deep",
+        {
+            "general": {"default_mode": "deep_research"},
+            "modes.deep_research": {"providers": ["openai"], "parallel": False},
+        },
+    )
+    profiles["all_deep"] = _build_profile_section(
+        "all_deep",
+        {
+            "general": {"default_mode": "deep_research"},
+            "modes.deep_research": {
+                "providers": ["openai", "perplexity"],
+                "parallel": True,
+            },
+        },
+    )
+    profiles["interactive"] = _build_profile_section(
+        "interactive", {"general": {"default_mode": "interactive"}}
+    )
+
+    profiles["deep_research"] = _build_profile_section(
+        "deep_research",
+        {
+            "general": {
+                "default_mode": "deep_research",
+                "prompt_prefix": "Be thorough. Cite primary sources where possible.",
+            },
+            "modes.deep_research": {
+                "providers": ["openai", "perplexity"],
+                "parallel": True,
+                "prompt_prefix": (
+                    "Be thorough. Cite primary sources. Include counter-arguments."
+                ),
+            },
+        },
+    )
+    return profiles
+
+
+def _build_starter_document() -> tomlkit.TOMLDocument:
+    """Construct the full `~/.config/thoth/config.toml` shipped by `thoth init`."""
+    doc = tomlkit.document()
+    doc.add(tomlkit.comment("Thoth Configuration File"))
+    doc["version"] = CONFIG_VERSION
+
+    general = tomlkit.table()
+    general["default_project"] = ""
+    general["default_mode"] = "default"
+    doc["general"] = general
+
+    paths = tomlkit.table()
+    paths["base_output_dir"] = "./research-outputs"
+    # Resolved against the user's checkpoint dir at init time.
+    from thoth.paths import user_checkpoints_dir
+
+    paths["checkpoint_dir"] = str(user_checkpoints_dir())
+    doc["paths"] = paths
+
+    execution = tomlkit.table()
+    execution["poll_interval"] = 30
+    execution["max_wait"] = 30
+    execution["parallel_providers"] = True
+    execution["retry_attempts"] = 3
+    execution["auto_input"] = True
+    doc["execution"] = execution
+
+    output = tomlkit.table()
+    output["combine_reports"] = False
+    output["format"] = "markdown"
+    output["include_metadata"] = True
+    output["timestamp_format"] = "%Y-%m-%d_%H%M%S"
+    doc["output"] = output
+
+    providers = tomlkit.table()
+    openai_t = tomlkit.table()
+    openai_t["api_key"] = "${OPENAI_API_KEY}"
+    providers["openai"] = openai_t
+    perplexity_t = tomlkit.table()
+    perplexity_t["api_key"] = "${PERPLEXITY_API_KEY}"
+    providers["perplexity"] = perplexity_t
+    doc["providers"] = providers
+
+    doc.add(tomlkit.nl())
+    doc.add(
+        tomlkit.comment(
+            "Configuration profiles (P21). Activate with --profile NAME,"
+        )
+    )
+    doc.add(
+        tomlkit.comment(
+            "THOTH_PROFILE=NAME, or general.default_profile."
+        )
+    )
+    doc.add(
+        tomlkit.comment(
+            "Profile values REPLACE top-level values when the profile is active."
+        )
+    )
+    doc["profiles"] = _build_starter_profiles()
+    return doc
 
 
 class CommandHandler:
@@ -121,35 +211,8 @@ class CommandHandler:
         console.print("[yellow]Interactive setup wizard not yet implemented.[/yellow]")
         console.print("Creating default configuration...")
 
-        config_manager = ConfigManager()
-        config_manager.load_all_layers()
-        config_data = config_manager.get_effective_config()
-
-        with open(config_path, "w") as f:
-            f.write("# Thoth Configuration File\n")
-            f.write(f'version = "{CONFIG_VERSION}"\n\n')
-            f.write("[general]\n")
-            f.write('default_project = ""\n')
-            f.write('default_mode = "default"\n\n')
-            f.write("[paths]\n")
-            f.write('base_output_dir = "./research-outputs"\n')
-            f.write(f'checkpoint_dir = "{config_data["paths"]["checkpoint_dir"]}"\n\n')
-            f.write("[execution]\n")
-            f.write("poll_interval = 30\n")
-            f.write("max_wait = 30\n")
-            f.write("parallel_providers = true\n")
-            f.write("retry_attempts = 3\n")
-            f.write("auto_input = true\n\n")
-            f.write("[output]\n")
-            f.write("combine_reports = false\n")
-            f.write('format = "markdown"\n')
-            f.write("include_metadata = true\n")
-            f.write('timestamp_format = "%Y-%m-%d_%H%M%S"\n\n')
-            f.write("[providers.openai]\n")
-            f.write('api_key = "${OPENAI_API_KEY}"\n\n')
-            f.write("[providers.perplexity]\n")
-            f.write('api_key = "${PERPLEXITY_API_KEY}"\n\n')
-            f.write(_starter_profiles_block())
+        doc = _build_starter_document()
+        config_path.write_text(tomlkit.dumps(doc))
 
         console.print(f"\n[green]✓[/green] Configuration saved to {config_path}")
         console.print('\nYou can now run: thoth deep_research "your prompt"')

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -33,7 +33,7 @@ from thoth.run import run_research
 console = Console()
 
 
-def _build_profile_section(name: str, body: dict[str, Any]) -> tomlkit.items.Table:
+def _build_profile_section(body: dict[str, Any]) -> tomlkit.items.Table:
     """Build a `[profiles.<name>]` table containing nested sub-tables.
 
     `body` is a flat dict whose keys are TOML section names under the profile
@@ -61,19 +61,16 @@ def _build_starter_profiles() -> tomlkit.items.Table:
     profiles = tomlkit.table()
 
     profiles["daily"] = _build_profile_section(
-        "daily",
         {"general": {"default_mode": "thinking", "default_project": "daily-notes"}},
     )
-    profiles["quick"] = _build_profile_section("quick", {"general": {"default_mode": "thinking"}})
+    profiles["quick"] = _build_profile_section({"general": {"default_mode": "thinking"}})
     profiles["openai_deep"] = _build_profile_section(
-        "openai_deep",
         {
             "general": {"default_mode": "deep_research"},
             "modes.deep_research": {"providers": ["openai"], "parallel": False},
         },
     )
     profiles["all_deep"] = _build_profile_section(
-        "all_deep",
         {
             "general": {"default_mode": "deep_research"},
             "modes.deep_research": {
@@ -82,12 +79,9 @@ def _build_starter_profiles() -> tomlkit.items.Table:
             },
         },
     )
-    profiles["interactive"] = _build_profile_section(
-        "interactive", {"general": {"default_mode": "interactive"}}
-    )
+    profiles["interactive"] = _build_profile_section({"general": {"default_mode": "interactive"}})
 
     profiles["deep_research"] = _build_profile_section(
-        "deep_research",
         {
             "general": {
                 "default_mode": "deep_research",

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -31,6 +31,55 @@ from thoth.run import run_research
 console = Console()
 
 
+def _starter_profiles_block() -> str:
+    """TOML block of example `[profiles.*]` sections shipped by `thoth init`.
+
+    Six worked examples that double as on-ramp documentation for the
+    `--profile NAME` plumbing and the `prompt_prefix` hierarchy. Users are
+    expected to customize/remove these.
+    """
+    return (
+        "# --- Configuration profiles (P21) -----------------------------------\n"
+        "# Activate with `thoth --profile NAME ...`, `THOTH_PROFILE=NAME`,\n"
+        "# or set `general.default_profile = \"NAME\"` above.\n"
+        "# Profile values REPLACE top-level values when the profile is active.\n"
+        "\n"
+        "[profiles.daily.general]\n"
+        'default_mode = "thinking"\n'
+        'default_project = "daily-notes"\n'
+        "\n"
+        "[profiles.quick.general]\n"
+        'default_mode = "thinking"\n'
+        "\n"
+        "[profiles.openai_deep.general]\n"
+        'default_mode = "deep_research"\n'
+        "[profiles.openai_deep.modes.deep_research]\n"
+        'providers = ["openai"]\n'
+        "parallel = false\n"
+        "\n"
+        "[profiles.all_deep.general]\n"
+        'default_mode = "deep_research"\n'
+        "[profiles.all_deep.modes.deep_research]\n"
+        'providers = ["openai", "perplexity"]\n'
+        "parallel = true\n"
+        "\n"
+        "[profiles.interactive.general]\n"
+        'default_mode = "interactive"\n'
+        "\n"
+        "# Worked example of the `prompt_prefix` hierarchy. The prefix below\n"
+        "# is prepended to the user's prompt when this profile is active and\n"
+        "# any deep_research run starts. Order: profile.modes.M > profile >\n"
+        "# modes.M > general (more-specific replaces less-specific).\n"
+        "[profiles.deep_research.general]\n"
+        'default_mode = "deep_research"\n'
+        'prompt_prefix = "Be thorough. Cite primary sources where possible."\n'
+        "[profiles.deep_research.modes.deep_research]\n"
+        'providers = ["openai", "perplexity"]\n'
+        "parallel = true\n"
+        'prompt_prefix = "Be thorough. Cite primary sources. Include counter-arguments."\n'
+    )
+
+
 class CommandHandler:
     """Unified command execution for CLI and interactive modes"""
 
@@ -99,7 +148,8 @@ class CommandHandler:
             f.write("[providers.openai]\n")
             f.write('api_key = "${OPENAI_API_KEY}"\n\n')
             f.write("[providers.perplexity]\n")
-            f.write('api_key = "${PERPLEXITY_API_KEY}"\n')
+            f.write('api_key = "${PERPLEXITY_API_KEY}"\n\n')
+            f.write(_starter_profiles_block())
 
         console.print(f"\n[green]✓[/green] Configuration saved to {config_path}")
         console.print('\nYou can now run: thoth deep_research "your prompt"')

--- a/src/thoth/commands.py
+++ b/src/thoth/commands.py
@@ -177,7 +177,7 @@ class CommandHandler:
             )
         return self.commands[command](**params)
 
-    def init_command(self, config_path: Path | None = None, **params):
+    def init_command(self, config_path: str | Path | None = None, **params):
         """Initialize Thoth configuration"""
         console.print("[bold]Welcome to Thoth Research Assistant Setup![/bold]\n")
 
@@ -188,6 +188,8 @@ class CommandHandler:
 
         if config_path is None:
             config_path = user_config_file()
+        else:
+            config_path = Path(config_path).expanduser()
         console.print(f"Configuration file will be created at: {config_path}\n")
 
         config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -236,6 +238,7 @@ class CommandHandler:
                 quiet=params.get("quiet", False),
                 no_metadata=params.get("no_metadata", False),
                 timeout_override=params.get("timeout_override"),
+                profile=params.get("profile"),
             )
         )
 
@@ -264,7 +267,7 @@ def get_init_data(*, non_interactive: bool, config_path: str | None) -> dict:
     created = not target.exists()
     if created:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text('version = "2.0"\n')
+        target.write_text(tomlkit.dumps(_build_starter_document()))
     return {
         "config_path": str(target),
         "created": created,
@@ -512,6 +515,7 @@ async def providers_command(
     no_cache: bool = False,
     cli_api_keys: dict[str, str | None] | None = None,
     timeout_override: float | None = None,
+    profile: str | None = None,
 ):
     """Show provider information and available models"""
     if not show_models and not show_list and not show_keys:
@@ -540,7 +544,7 @@ async def providers_command(
         console.print("  $ thoth providers models --no-cache")
         return
 
-    config = get_config()
+    config = get_config(profile=profile)
     cli_api_keys = cli_api_keys or {}
 
     all_providers = ["openai", "perplexity", "mock"]

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -22,6 +22,14 @@ from typing import Any
 from rich.console import Console
 
 from thoth import __version__
+from thoth.config_profiles import (
+    ProfileLayer,
+    ProfileSelection,
+    collect_profile_catalog,
+    resolve_profile_layer,
+    resolve_profile_selection,
+    without_profiles,
+)
 from thoth.errors import ThothError
 from thoth.paths import user_checkpoints_dir, user_config_file
 
@@ -273,28 +281,65 @@ class ConfigManager:
     def __init__(self, config_path: Path | None = None):
         self.user_config_path = config_path or user_config_file()
         self.project_config_paths = ["./thoth.toml", "./.thoth/config.toml"]
-        self.layers = {}
-        self.data = {}
+        self.layers: dict[str, dict[str, Any]] = {}
+        self.data: dict[str, Any] = {}
+        self.project_config_path: Path | None = None
+        self.profile_selection: ProfileSelection = ProfileSelection(None, "none", None)
+        self.active_profile: ProfileLayer | None = None
+        self.profile_catalog: list[ProfileLayer] = []
 
     def load_all_layers(self, cli_args: dict[str, Any] | None = None):
         """Load all configuration layers in precedence order"""
+        raw_cli_args = cli_args or {}
+        cli_profile = raw_cli_args.get("_profile")
+        cli_layer = {key: value for key, value in raw_cli_args.items() if key != "_profile"}
+
         # Layer 1: Internal defaults
         self.layers["defaults"] = ConfigSchema.get_defaults()
 
-        # Layer 2: User config file
+        # Layer 2: User config file (raw, including any [profiles.*] tables)
         if self.user_config_path.exists():
-            self.layers["user"] = self._load_toml_file(self.user_config_path)
+            user_raw = self._load_toml_file(self.user_config_path)
         else:
-            self.layers["user"] = {}
+            user_raw = {}
 
-        # Layer 3: Project config file (if exists)
-        self.layers["project"] = self._load_project_config()
+        # Layer 3: Project config file (raw + actual path used)
+        project_raw, project_path = self._load_project_config_with_path()
+        self.project_config_path = project_path
 
-        # Layer 4: Environment variables
+        # Build the profile catalog from the raw layer data BEFORE stripping
+        # profiles, then strip [profiles.*] tables out of the merged user/project
+        # layers so they never participate in the regular layer merge.
+        self.profile_catalog = collect_profile_catalog(
+            user_config=user_raw,
+            project_config=project_raw,
+            user_path=self.user_config_path,
+            project_path=project_path,
+        )
+        self.layers["user"] = without_profiles(user_raw)
+        self.layers["project"] = without_profiles(project_raw)
+
+        # Resolve which profile is active using a base view that contains
+        # defaults + user + project (no env, no CLI). This honors
+        # general.default_profile if set in either config file.
+        base_config: dict[str, Any] = {}
+        for layer_name in ["defaults", "user", "project"]:
+            base_config = self._deep_merge(base_config, self.layers[layer_name])
+
+        self.profile_selection = resolve_profile_selection(
+            cli_profile=str(cli_profile) if cli_profile else None,
+            base_config=base_config,
+        )
+        self.active_profile = resolve_profile_layer(
+            self.profile_selection, self.profile_catalog
+        )
+        self.layers["profile"] = self.active_profile.data if self.active_profile else {}
+
+        # Layer 5: Environment variables (per-setting overrides only)
         self.layers["env"] = self._get_env_overrides()
 
-        # Layer 5: CLI arguments
-        self.layers["cli"] = cli_args or {}
+        # Layer 6: CLI arguments (per-setting overrides only; _profile sentinel stripped)
+        self.layers["cli"] = cli_layer
 
         # Merge all layers
         self.data = self._merge_layers()
@@ -323,13 +368,18 @@ class ConfigManager:
             _console.print(f"[yellow]Warning:[/yellow] Failed to load {path}: {e}")
             return {}
 
-    def _load_project_config(self) -> dict[str, Any]:
-        """Load project-level configuration if it exists"""
+    def _load_project_config_with_path(self) -> tuple[dict[str, Any], Path | None]:
+        """Load project-level configuration if it exists; also return its path."""
         for config_path in self.project_config_paths:
             path = Path(config_path)
             if path.exists():
-                return self._load_toml_file(path)
-        return {}
+                return self._load_toml_file(path), path
+        return {}, None
+
+    def _load_project_config(self) -> dict[str, Any]:
+        """Load project-level configuration if it exists"""
+        data, _ = self._load_project_config_with_path()
+        return data
 
     def _get_env_overrides(self) -> dict[str, Any]:
         """Get configuration overrides from environment variables"""
@@ -373,7 +423,7 @@ class ConfigManager:
         result = {}
 
         # Merge in order of precedence
-        for layer_name in ["defaults", "user", "project", "env", "cli"]:
+        for layer_name in ["defaults", "user", "project", "profile", "env", "cli"]:
             if layer_name in self.layers and self.layers[layer_name]:
                 result = self._deep_merge(result, self.layers[layer_name])
 

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -291,6 +291,25 @@ class ConfigManager:
     def load_all_layers(self, cli_args: dict[str, Any] | None = None):
         """Load all configuration layers in precedence order"""
         raw_cli_args = cli_args or {}
+
+        # Defense-in-depth (BUG-05): cli_args is the CLI override LAYER for
+        # config values. Its keys must be either the `_profile` sentinel or
+        # top-level config-schema keys (e.g., "general", "execution"). Anything
+        # else is a programming error — most commonly someone confusing this
+        # with a generic options bag and passing metadata like "config_path"
+        # (which belongs in the ConfigManager(config_path=...) constructor).
+        allowed_top_level = set(ConfigSchema.get_defaults().keys())
+        for key in raw_cli_args:
+            if key == "_profile" or key in allowed_top_level:
+                continue
+            raise ValueError(
+                f"cli_args key {key!r} is not a known config root or sentinel. "
+                f"Allowed: '_profile' or one of {sorted(allowed_top_level)}. "
+                f"If {key!r} is metadata about which file to load (e.g. "
+                f"'config_path'), pass it to ConfigManager(config_path=...) "
+                f"instead."
+            )
+
         cli_profile = raw_cli_args.get("_profile")
         cli_layer = {key: value for key, value in raw_cli_args.items() if key != "_profile"}
 

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -569,8 +569,11 @@ class ConfigManager:
         return self.data
 
 
-def get_config() -> ConfigManager:
+def get_config(profile: str | None = None) -> ConfigManager:
     """Get a fully-loaded ConfigManager instance with custom path if provided"""
     manager = ConfigManager(_config_path) if _config_path else ConfigManager()
-    manager.load_all_layers()
+    cli_args: dict[str, Any] = {}
+    if profile:
+        cli_args["_profile"] = profile
+    manager.load_all_layers(cli_args)
     return manager

--- a/src/thoth/config.py
+++ b/src/thoth/config.py
@@ -330,9 +330,7 @@ class ConfigManager:
             cli_profile=str(cli_profile) if cli_profile else None,
             base_config=base_config,
         )
-        self.active_profile = resolve_profile_layer(
-            self.profile_selection, self.profile_catalog
-        )
+        self.active_profile = resolve_profile_layer(self.profile_selection, self.profile_catalog)
         self.layers["profile"] = self.active_profile.data if self.active_profile else {}
 
         # Layer 5: Environment variables (per-setting overrides only)

--- a/src/thoth/config_cmd.py
+++ b/src/thoth/config_cmd.py
@@ -27,9 +27,16 @@ def _normalize_config_path(config_path: str | Path | None) -> Path | None:
     return Path(config_path).expanduser().resolve()
 
 
-def _load_manager(config_path: str | Path | None = None) -> ConfigManager:
+def _load_manager(
+    config_path: str | Path | None = None,
+    *,
+    profile: str | None = None,
+) -> ConfigManager:
     cm = ConfigManager(_normalize_config_path(config_path))
-    cm.load_all_layers({})
+    cli_args: dict[str, Any] = {}
+    if profile:
+        cli_args["_profile"] = profile
+    cm.load_all_layers(cli_args)
     return cm
 
 
@@ -60,6 +67,7 @@ def get_config_get_data(
     raw: bool,
     show_secrets: bool,
     config_path: str | Path | None = None,
+    profile: str | None = None,
 ) -> dict:
     """Pure data function for `thoth config get KEY`.
 
@@ -67,7 +75,7 @@ def get_config_get_data(
     `layer` is invalid, includes `error="INVALID_LAYER"`. Per spec §7.2,
     this function NEVER takes an `as_json` flag.
     """
-    cm = _load_manager(config_path)
+    cm = _load_manager(config_path, profile=profile)
 
     if layer is not None:
         if layer not in _VALID_LAYERS:
@@ -107,7 +115,12 @@ def get_config_get_data(
     }
 
 
-def _op_get(args: list[str], *, config_path: str | Path | None = None) -> int:
+def _op_get(
+    args: list[str],
+    *,
+    config_path: str | Path | None = None,
+    profile: str | None = None,
+) -> int:
     layer: str | None = None
     raw = False
     as_json = False
@@ -141,7 +154,12 @@ def _op_get(args: list[str], *, config_path: str | Path | None = None) -> int:
     key = positional[0]
 
     data = get_config_get_data(
-        key, layer=layer, raw=raw, show_secrets=show_secrets, config_path=config_path
+        key,
+        layer=layer,
+        raw=raw,
+        show_secrets=show_secrets,
+        config_path=config_path,
+        profile=profile,
     )
 
     if data.get("error") == "INVALID_LAYER":
@@ -406,9 +424,10 @@ def get_config_list_data(
     keys_only: bool,
     show_secrets: bool,
     config_path: str | Path | None = None,
+    profile: str | None = None,
 ) -> dict:
     """Pure data function for `thoth config list`."""
-    cm = _load_manager(config_path)
+    cm = _load_manager(config_path, profile=profile)
 
     if layer is not None:
         if layer not in _VALID_LAYERS:
@@ -431,7 +450,12 @@ def get_config_list_data(
     return {"config": rendered, "layer": layer}
 
 
-def _op_list(args: list[str], *, config_path: str | Path | None = None) -> int:
+def _op_list(
+    args: list[str],
+    *,
+    config_path: str | Path | None = None,
+    profile: str | None = None,
+) -> int:
     layer: str | None = None
     keys_only = False
     as_json = False
@@ -464,7 +488,7 @@ def _op_list(args: list[str], *, config_path: str | Path | None = None) -> int:
             console.print(f"[red]Error:[/red] unknown arg: {a}")
             return 2
 
-    cm = _load_manager(config_path)
+    cm = _load_manager(config_path, profile=profile)
 
     if layer is not None:
         if layer not in _VALID_LAYERS:
@@ -566,21 +590,31 @@ def _op_edit(args: list[str], *, config_path: str | Path | None = None) -> int:
     return int(data["editor_exit_code"])
 
 
-def config_command(op: str, args: list[str], *, config_path: str | Path | None = None) -> int:
+def config_command(
+    op: str,
+    args: list[str],
+    *,
+    config_path: str | Path | None = None,
+    profile: str | None = None,
+) -> int:
     """Dispatch `thoth config <op>`. Returns a process exit code."""
-    ops = {
-        "get": _op_get,
-        "set": _op_set,
-        "unset": _op_unset,
-        "list": _op_list,
-        "path": _op_path,
-        "edit": _op_edit,
-        "help": _op_help,
-    }
-    if op not in ops:
+    if op not in {"get", "set", "unset", "list", "path", "edit", "help"}:
         console.print(f"[red]Error:[/red] unknown config op: {op}")
         return 2
-    return ops[op](args, config_path=config_path)
+
+    if op == "get":
+        return _op_get(args, config_path=config_path, profile=profile)
+    if op == "list":
+        return _op_list(args, config_path=config_path, profile=profile)
+    if op == "set":
+        return _op_set(args, config_path=config_path)
+    if op == "unset":
+        return _op_unset(args, config_path=config_path)
+    if op == "path":
+        return _op_path(args, config_path=config_path)
+    if op == "edit":
+        return _op_edit(args, config_path=config_path)
+    return _op_help(args, config_path=config_path)
 
 
 __all__ = [

--- a/src/thoth/config_cmd.py
+++ b/src/thoth/config_cmd.py
@@ -17,7 +17,7 @@ from thoth.paths import user_config_file
 
 console = Console()
 
-_VALID_LAYERS = ("defaults", "user", "project", "env", "cli")
+_VALID_LAYERS = ("defaults", "user", "project", "profile", "env", "cli")
 _ROOT_KEYS_ALLOW_UNKNOWN = ("modes",)
 
 

--- a/src/thoth/config_profiles.py
+++ b/src/thoth/config_profiles.py
@@ -92,3 +92,52 @@ def resolve_profile_layer(
 
 def without_profiles(config: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in config.items() if key != "profiles"}
+
+
+def _nonempty_str(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def resolve_prompt_prefix(config: Any, mode: str) -> str | None:
+    """Resolve `prompt_prefix` for ``mode`` using the 4-level hierarchy.
+
+    Order (most-specific first):
+      1. profiles.<active>.modes.<MODE>.prompt_prefix
+      2. profiles.<active>.prompt_prefix
+      3. modes.<MODE>.prompt_prefix
+      4. general.prompt_prefix
+
+    More-specific REPLACES less-specific. Empty strings are treated as unset
+    so they cannot accidentally erase outer values.
+    """
+    profile = getattr(config, "active_profile", None)
+    if profile is not None:
+        profile_data = profile.data if isinstance(profile.data, dict) else {}
+        profile_modes = profile_data.get("modes")
+        if isinstance(profile_modes, dict):
+            mode_table = profile_modes.get(mode)
+            if isinstance(mode_table, dict):
+                hit = _nonempty_str(mode_table.get("prompt_prefix"))
+                if hit is not None:
+                    return hit
+        hit = _nonempty_str(profile_data.get("prompt_prefix"))
+        if hit is not None:
+            return hit
+
+    data = getattr(config, "data", {}) or {}
+    modes = data.get("modes") if isinstance(data, dict) else None
+    if isinstance(modes, dict):
+        mode_table = modes.get(mode)
+        if isinstance(mode_table, dict):
+            hit = _nonempty_str(mode_table.get("prompt_prefix"))
+            if hit is not None:
+                return hit
+
+    general = data.get("general") if isinstance(data, dict) else None
+    if isinstance(general, dict):
+        hit = _nonempty_str(general.get("prompt_prefix"))
+        if hit is not None:
+            return hit
+    return None

--- a/src/thoth/config_profiles.py
+++ b/src/thoth/config_profiles.py
@@ -1,0 +1,90 @@
+"""Configuration profile resolution for Thoth."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from thoth.errors import ConfigProfileError
+
+ProfileSelectionSource = Literal["flag", "env", "config", "none"]
+ProfileTier = Literal["project", "user"]
+
+
+@dataclass(frozen=True)
+class ProfileSelection:
+    name: str | None
+    source: ProfileSelectionSource
+    source_detail: str | None
+
+
+@dataclass(frozen=True)
+class ProfileLayer:
+    name: str
+    tier: ProfileTier
+    path: Path
+    data: dict[str, Any]
+
+
+def _profiles_from(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = config.get("profiles") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(name): value for name, value in raw.items() if isinstance(value, dict)}
+
+
+def collect_profile_catalog(
+    *,
+    user_config: dict[str, Any],
+    project_config: dict[str, Any],
+    user_path: Path,
+    project_path: Path | None,
+) -> list[ProfileLayer]:
+    catalog: list[ProfileLayer] = []
+    for name, data in _profiles_from(user_config).items():
+        catalog.append(ProfileLayer(name=name, tier="user", path=user_path, data=data))
+    if project_path is not None:
+        for name, data in _profiles_from(project_config).items():
+            catalog.append(ProfileLayer(name=name, tier="project", path=project_path, data=data))
+    return catalog
+
+
+def resolve_profile_selection(
+    *,
+    cli_profile: str | None,
+    base_config: dict[str, Any],
+) -> ProfileSelection:
+    if cli_profile:
+        return ProfileSelection(cli_profile, "flag", "--profile flag")
+    env_profile = os.getenv("THOTH_PROFILE")
+    if env_profile:
+        return ProfileSelection(env_profile, "env", "THOTH_PROFILE")
+    general = base_config.get("general") or {}
+    config_profile = general.get("default_profile") if isinstance(general, dict) else None
+    if config_profile:
+        return ProfileSelection(str(config_profile), "config", "general.default_profile")
+    return ProfileSelection(None, "none", None)
+
+
+def resolve_profile_layer(
+    selection: ProfileSelection,
+    catalog: list[ProfileLayer],
+) -> ProfileLayer | None:
+    if selection.name is None:
+        return None
+
+    matches = [entry for entry in catalog if entry.name == selection.name]
+    if not matches:
+        available = sorted({entry.name for entry in catalog})
+        raise ConfigProfileError(
+            f"Profile {selection.name!r} not found",
+            available_profiles=available,
+            source=selection.source_detail,
+        )
+
+    project_matches = [entry for entry in matches if entry.tier == "project"]
+    if project_matches:
+        return project_matches[-1]
+    return matches[-1]

--- a/src/thoth/config_profiles.py
+++ b/src/thoth/config_profiles.py
@@ -88,3 +88,7 @@ def resolve_profile_layer(
     if project_matches:
         return project_matches[-1]
     return matches[-1]
+
+
+def without_profiles(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key != "profiles"}

--- a/src/thoth/config_profiles.py
+++ b/src/thoth/config_profiles.py
@@ -141,3 +141,17 @@ def resolve_prompt_prefix(config: Any, mode: str) -> str | None:
         if hit is not None:
             return hit
     return None
+
+
+def assemble_prompt_with_prefix(config: Any, mode: str, user_prompt: str) -> str:
+    """Return the user message that should reach the provider.
+
+    If a `prompt_prefix` resolves for ``mode`` under ``config`` (4-level
+    hierarchy via ``resolve_prompt_prefix``), the result is
+    ``f"{prefix}\\n\\n{user_prompt}"``. Otherwise ``user_prompt`` is returned
+    unchanged. The mode's ``system_prompt`` is unaffected.
+    """
+    prefix = resolve_prompt_prefix(config, mode)
+    if prefix is None:
+        return user_prompt
+    return f"{prefix}\n\n{user_prompt}"

--- a/src/thoth/errors.py
+++ b/src/thoth/errors.py
@@ -91,6 +91,27 @@ class APIQuotaError(ThothError):
         )
 
 
+class ConfigProfileError(ThothError):
+    """Configuration profile selection or validation failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        available_profiles: list[str] | None = None,
+        source: str | None = None,
+    ):
+        details = message if source is None else f"{message} (from {source})"
+        suggestion_parts = ["Run `thoth config profiles list` to see available profiles."]
+        if available_profiles:
+            suggestion_parts.append(f"Available profiles: {', '.join(available_profiles)}.")
+        super().__init__(
+            details,
+            " ".join(suggestion_parts),
+            exit_code=1,
+        )
+
+
 class ModeKindMismatchError(ThothError):
     """A mode's declared `kind` is incompatible with its model's required kind.
 

--- a/src/thoth/help.py
+++ b/src/thoth/help.py
@@ -215,9 +215,7 @@ def show_config_help():
     console.print("  execution.prompt_max_bytes  Cap on --prompt-file / stdin bytes")
     console.print("                              (default: 1048576 = 1 MiB)")
     console.print("\n[bold]Profile selection:[/bold]")
-    console.print(
-        "  --profile NAME (also THOTH_PROFILE env, or general.default_profile in config)"
-    )
+    console.print("  --profile NAME (also THOTH_PROFILE env, or general.default_profile in config)")
     console.print("  Profile sections live under [profiles.<name>] and overlay top-level config.")
     console.print(
         "  CLI management commands (`thoth config profiles ...`) ship in a follow-up project (P21b)."

--- a/src/thoth/help.py
+++ b/src/thoth/help.py
@@ -214,6 +214,14 @@ def show_config_help():
     console.print("\n[bold]Notable keys:[/bold]")
     console.print("  execution.prompt_max_bytes  Cap on --prompt-file / stdin bytes")
     console.print("                              (default: 1048576 = 1 MiB)")
+    console.print("\n[bold]Profile selection:[/bold]")
+    console.print(
+        "  --profile NAME (also THOTH_PROFILE env, or general.default_profile in config)"
+    )
+    console.print("  Profile sections live under [profiles.<name>] and overlay top-level config.")
+    console.print(
+        "  CLI management commands (`thoth config profiles ...`) ship in a follow-up project (P21b)."
+    )
     console.print("\n[bold]Notes:[/bold]")
     console.print("  API key values are masked by default; use --show-secrets to reveal.")
     console.print("  Writes preserve comments and formatting of the target TOML file.")

--- a/src/thoth/interactive.py
+++ b/src/thoth/interactive.py
@@ -1002,13 +1002,14 @@ async def enter_interactive_mode(
     quiet: bool,
     no_metadata: bool,
     timeout: float | None,
+    profile: str | None = None,
 ):
     """Enter interactive prompt mode with Prompt Toolkit"""
     if not PROMPT_TOOLKIT_AVAILABLE:
         console.print(
             "[yellow]Warning: prompt_toolkit not available, falling back to basic input[/yellow]"
         )
-        config = get_config()
+        config = get_config(profile=profile)
         console.print("[bold cyan]Interactive Mode (Basic)[/bold cyan]")
         console.print("[dim]Enter prompt • /help: commands • /exit: quit[/dim]")
         console.print()
@@ -1050,13 +1051,14 @@ async def enter_interactive_mode(
                         quiet=quiet,
                         no_metadata=no_metadata,
                         timeout_override=timeout,
+                        profile=profile,
                     )
                     break
         except (KeyboardInterrupt, EOFError):
             console.print("\n[yellow]Interactive mode cancelled[/yellow]")
         return
 
-    config = get_config()
+    config = get_config(profile=profile)
 
     session = InteractiveSession(console, config, initial_settings)
 
@@ -1090,6 +1092,7 @@ async def enter_interactive_mode(
             quiet=quiet,
             no_metadata=no_metadata,
             timeout_override=timeout,
+            profile=profile,
         )
 
     except Exception as e:

--- a/src/thoth/run.py
+++ b/src/thoth/run.py
@@ -212,6 +212,10 @@ async def run_research(
     if not mode or not prompt:
         raise click.BadParameter("Both mode and prompt are required for research operations")
 
+    from thoth.config_profiles import assemble_prompt_with_prefix
+
+    prompt = assemble_prompt_with_prefix(config, mode, prompt)
+
     operation_id = generate_operation_id()
 
     if verbose:

--- a/src/thoth/run.py
+++ b/src/thoth/run.py
@@ -187,6 +187,7 @@ async def run_research(
     model_override: str | None = None,
     out_specs: tuple[str, ...] = (),
     append: bool = False,
+    profile: str | None = None,
 ):
     """Execute research operation.
 
@@ -196,7 +197,7 @@ async def run_research(
     threading ctx through every test case.
     """
 
-    config = get_config()
+    config = get_config(profile=profile)
     if ctx is None:
         ctx = AppContext(config=config, verbose=verbose)
     console = ctx.console  # noqa: F811 — shadow module-level console with ctx's

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from thoth.__main__ import ConfigManager, get_config
 
 
@@ -12,3 +14,30 @@ def test_get_config_returns_config_manager() -> None:
     # Must be loaded: ConfigManager() alone leaves .data empty until load_all_layers runs.
     assert cfg.data, "expected get_config() to return a loaded ConfigManager"
     assert "providers" in cfg.data
+
+
+def test_load_all_layers_rejects_unknown_cli_args_keys() -> None:
+    """BUG-05 (B): cli_args is a CLI override LAYER, not a generic options bag.
+
+    Misuse like ``{"config_path": ...}`` (which belongs in the
+    ``ConfigManager(config_path=...)`` constructor) must raise at the
+    boundary instead of silently polluting ``cm.data``.
+    """
+    cm = ConfigManager()
+    with pytest.raises(ValueError, match=r"cli_args key 'config_path'"):
+        cm.load_all_layers({"config_path": None})
+
+    with pytest.raises(ValueError, match=r"cli_args key 'arbitrary_key'"):
+        cm.load_all_layers({"arbitrary_key": "x"})
+
+
+def test_load_all_layers_accepts_profile_sentinel_and_known_top_level_keys() -> None:
+    """The validator must not regress against legitimate cli_args shapes."""
+    cm = ConfigManager()
+    # Empty dict
+    cm.load_all_layers({})
+    # Sentinel only (no profile registered, but the empty selection path is fine)
+    cm.load_all_layers({})
+    # Known top-level config root: nested override
+    cm.load_all_layers({"execution": {"poll_interval": 99}})
+    assert cm.data["execution"]["poll_interval"] == 99

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -37,6 +37,52 @@ def test_get_layer_defaults(isolated_thoth_home: Path, capsys: pytest.CaptureFix
     assert out == "default"
 
 
+def test_get_layer_profile_returns_profile_overlay(
+    isolated_thoth_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """C9: --layer profile must return the active profile's overlay (not merged)."""
+    user_toml = Path(isolated_thoth_home) / "config" / "thoth" / "config.toml"
+    user_toml.parent.mkdir(parents=True, exist_ok=True)
+    user_toml.write_text(
+        'version = "2.0"\n'
+        "[general]\n"
+        'default_mode = "default"\n'
+        "[profiles.fast.general]\n"
+        'default_mode = "thinking"\n'
+    )
+
+    rc = config_command(
+        "get",
+        ["--layer", "profile", "general.default_mode"],
+        profile="fast",
+    )
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert out == "thinking", f"expected profile-overlay value, got {out!r}"
+
+
+def test_get_raw_includes_profile_layer(
+    isolated_thoth_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """C9: --raw must merge the profile layer (not silently omit it)."""
+    user_toml = Path(isolated_thoth_home) / "config" / "thoth" / "config.toml"
+    user_toml.parent.mkdir(parents=True, exist_ok=True)
+    user_toml.write_text(
+        'version = "2.0"\n'
+        "[general]\n"
+        'default_mode = "default"\n'
+        "[profiles.fast.general]\n"
+        'default_mode = "thinking"\n'
+    )
+
+    rc = config_command("get", ["--raw", "general.default_mode"], profile="fast")
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert out == "thinking", (
+        f"--raw must include profile-layer overlay; expected 'thinking', got {out!r}"
+    )
+
+
 def test_get_raw_preserves_env_template(
     isolated_thoth_home: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_config_profile_cli_integration.py
+++ b/tests/test_config_profile_cli_integration.py
@@ -1,0 +1,193 @@
+"""End-to-end CLI coverage for P21 profile propagation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from thoth.cli import cli
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the process-wide --config override from leaking between tests."""
+    from thoth import config as thoth_config
+
+    monkeypatch.setattr(thoth_config, "_config_path", None)
+
+
+def _write_profile_config(path: Path) -> None:
+    path.write_text(
+        """
+version = "2.0"
+
+[profiles.fast]
+prompt_prefix = "PROFILE_FLAG"
+
+[profiles.fast.general]
+default_mode = "thinking"
+
+[profiles.fast.providers.mock]
+api_key = "test"
+""".strip()
+        + "\n"
+    )
+
+
+def test_root_profile_applies_prompt_prefix_to_ask_research(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "thoth.toml"
+    out = tmp_path / "out.txt"
+    _write_profile_config(cfg)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config",
+            str(cfg),
+            "--profile",
+            "fast",
+            "ask",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--api-key-mock",
+            "test",
+            "--quiet",
+            "--out",
+            str(out),
+            "hello",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Echo: PROFILE_FLAG\n\nhello" in out.read_text()
+
+
+def test_missing_root_profile_fails_research_before_provider(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "thoth.toml"
+    out = tmp_path / "out.txt"
+    _write_profile_config(cfg)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config",
+            str(cfg),
+            "--profile",
+            "missing",
+            "ask",
+            "--mode",
+            "thinking",
+            "--provider",
+            "mock",
+            "--api-key-mock",
+            "test",
+            "--quiet",
+            "--out",
+            str(out),
+            "hello",
+        ],
+    )
+
+    combined_error = f"{result.output}\n{result.exception!r}"
+    assert result.exit_code == 1
+    assert "Profile 'missing' not found" in combined_error
+    assert not out.exists()
+
+
+def test_profile_default_mode_used_for_bare_prompt(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "thoth.toml"
+    out = tmp_path / "out.txt"
+    _write_profile_config(cfg)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config",
+            str(cfg),
+            "--profile",
+            "fast",
+            "--provider",
+            "mock",
+            "--api-key-mock",
+            "test",
+            "--quiet",
+            "--out",
+            str(out),
+            "hello",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "# Mock streaming response (mode=thinking)" in out.read_text()
+
+
+def test_providers_check_honors_root_profile_provider_key(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "thoth.toml"
+    _write_profile_config(cfg)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config",
+            str(cfg),
+            "--profile",
+            "fast",
+            "providers",
+            "check",
+            "--provider",
+            "mock",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "set" in result.output
+    assert "missing" not in result.output
+
+
+def test_config_get_json_missing_profile_emits_json_error(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "thoth.toml"
+    _write_profile_config(cfg)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config",
+            str(cfg),
+            "--profile",
+            "missing",
+            "config",
+            "get",
+            "general.default_mode",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.output.startswith("{"), result.output or repr(result.exception)
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "CONFIG_PROFILE_ERROR"
+    assert "Profile 'missing' not found" in payload["error"]["message"]

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from thoth.cli import cli
+from thoth.config import ConfigManager
 from thoth.config_profiles import (
     ProfileSelection,
     collect_profile_catalog,
@@ -126,9 +129,6 @@ def test_missing_profile_raises_for_each_selection_source(
     with pytest.raises(ConfigProfileError) as exc:
         resolve_profile_layer(selection, catalog)
     assert detail_substring in exc.value.message
-
-
-from thoth.config import ConfigManager
 
 
 def _write(path: Path, text: str) -> None:
@@ -254,8 +254,10 @@ default_mode = "thinking"
 
     assert cm.active_profile is not None
     assert cm.active_profile.tier == "project"
-    assert cm.active_profile.path == Path(".thoth/config.toml") or \
-           cm.active_profile.path.name == "config.toml"
+    assert (
+        cm.active_profile.path == Path(".thoth/config.toml")
+        or cm.active_profile.path.name == "config.toml"
+    )
 
 
 def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
@@ -269,11 +271,6 @@ def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
         "THOTH_PROFILE belongs to Stage 1 selection (read by resolve_profile_selection), "
         "not Stage 2 per-setting overrides. See CPP REQ-CPP-004."
     )
-
-
-from click.testing import CliRunner
-
-from thoth.cli import cli
 
 
 def test_root_profile_reaches_config_get(isolated_thoth_home: Path) -> None:

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -126,3 +126,146 @@ def test_missing_profile_raises_for_each_selection_source(
     with pytest.raises(ConfigProfileError) as exc:
         resolve_profile_layer(selection, catalog)
     assert detail_substring in exc.value.message
+
+
+from thoth.config import ConfigManager
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_config_manager_no_profile_keeps_existing_effective_config(
+    isolated_thoth_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    cm = ConfigManager()
+    cm.load_all_layers({})
+    assert cm.get("general.default_mode") == "default"
+    assert cm.profile_selection.name is None
+    assert cm.active_profile is None
+
+
+def test_config_manager_applies_profile_between_project_and_env(
+    isolated_thoth_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from thoth.paths import user_config_file
+
+    monkeypatch.setenv("THOTH_PROFILE", "fast")
+    monkeypatch.setenv("THOTH_DEFAULT_MODE", "clarification")
+    _write(
+        user_config_file(),
+        """
+version = "2.0"
+
+[general]
+default_mode = "deep_research"
+
+[profiles.fast.general]
+default_mode = "thinking"
+""".strip()
+        + "\n",
+    )
+
+    cm = ConfigManager()
+    cm.load_all_layers({})
+
+    assert cm.get("general.default_mode") == "clarification"
+    assert cm.layers["profile"]["general"]["default_mode"] == "thinking"
+    assert cm.profile_selection.name == "fast"
+    assert cm.active_profile is not None
+    assert cm.active_profile.tier == "user"
+
+
+def test_cli_setting_override_beats_active_profile(isolated_thoth_home: Path) -> None:
+    from thoth.paths import user_config_file
+
+    _write(
+        user_config_file(),
+        """
+version = "2.0"
+
+[profiles.fast.execution]
+poll_interval = 5
+""".strip()
+        + "\n",
+    )
+
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "fast", "execution": {"poll_interval": 99}})
+
+    assert cm.get("execution.poll_interval") == 99
+    assert cm.layers["profile"]["execution"]["poll_interval"] == 5
+
+
+def test_default_profile_pointer_survives_profile_splitting(
+    isolated_thoth_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from thoth.paths import user_config_file
+
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    _write(
+        user_config_file(),
+        """
+version = "2.0"
+
+[general]
+default_profile = "fast"
+
+[profiles.fast.general]
+default_mode = "thinking"
+""".strip()
+        + "\n",
+    )
+
+    cm = ConfigManager()
+    cm.load_all_layers({})
+
+    assert cm.get("general.default_profile") == "fast"
+    assert cm.profile_selection.name == "fast"
+    assert cm.profile_selection.source == "config"
+
+
+def test_config_manager_uses_dot_thoth_project_file_when_present(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog must report the actual project file used (covers both project_config_paths)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    _write(
+        tmp_path / ".thoth" / "config.toml",
+        """
+version = "2.0"
+
+[profiles.proj.general]
+default_mode = "thinking"
+""".strip()
+        + "\n",
+    )
+
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "proj"})
+
+    assert cm.active_profile is not None
+    assert cm.active_profile.tier == "project"
+    assert cm.active_profile.path == Path(".thoth/config.toml") or \
+           cm.active_profile.path.name == "config.toml"
+
+
+def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
+    """Regression guard: THOTH_PROFILE must not be added to env_mappings."""
+    import inspect
+
+    from thoth import config as thoth_config
+
+    src = inspect.getsource(thoth_config.ConfigManager._get_env_overrides)
+    assert "THOTH_PROFILE" not in src, (
+        "THOTH_PROFILE belongs to Stage 1 selection (read by resolve_profile_selection), "
+        "not Stage 2 per-setting overrides. See CPP REQ-CPP-004."
+    )

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from thoth.config_profiles import (
+    ProfileSelection,
+    collect_profile_catalog,
+    resolve_profile_layer,
+    resolve_profile_selection,
+)
+from thoth.errors import ConfigProfileError
+
+
+def test_resolve_profile_selection_prefers_flag_over_env_and_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("THOTH_PROFILE", "env-profile")
+    selection = resolve_profile_selection(
+        cli_profile="flag-profile",
+        base_config={"general": {"default_profile": "config-profile"}},
+    )
+    assert selection == ProfileSelection(
+        name="flag-profile",
+        source="flag",
+        source_detail="--profile flag",
+    )
+
+
+def test_resolve_profile_selection_uses_env_before_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("THOTH_PROFILE", "env-profile")
+    selection = resolve_profile_selection(
+        cli_profile=None,
+        base_config={"general": {"default_profile": "config-profile"}},
+    )
+    assert selection.name == "env-profile"
+    assert selection.source == "env"
+    assert selection.source_detail == "THOTH_PROFILE"
+
+
+def test_resolve_profile_selection_uses_config_pointer_when_flag_and_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    selection = resolve_profile_selection(
+        cli_profile=None,
+        base_config={"general": {"default_profile": "config-profile"}},
+    )
+    assert selection.name == "config-profile"
+    assert selection.source == "config"
+    assert selection.source_detail == "general.default_profile"
+
+
+def test_resolve_profile_selection_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    selection = resolve_profile_selection(cli_profile=None, base_config={"general": {}})
+    assert selection.name is None
+    assert selection.source == "none"
+    assert selection.source_detail is None
+
+
+def test_project_profile_shadows_user_profile_wholesale(tmp_path: Path) -> None:
+    catalog = collect_profile_catalog(
+        user_config={"profiles": {"prod": {"general": {"default_mode": "thinking"}}}},
+        project_config={"profiles": {"prod": {"execution": {"poll_interval": 5}}}},
+        user_path=tmp_path / "user.toml",
+        project_path=tmp_path / "thoth.toml",
+    )
+    layer = resolve_profile_layer(
+        ProfileSelection("prod", "flag", "--profile flag"),
+        catalog,
+    )
+    assert layer is not None
+    assert layer.tier == "project"
+    assert layer.data == {"execution": {"poll_interval": 5}}
+
+
+def test_collect_catalog_skips_project_when_no_project_file(tmp_path: Path) -> None:
+    catalog = collect_profile_catalog(
+        user_config={"profiles": {"prod": {"general": {}}}},
+        project_config={},
+        user_path=tmp_path / "user.toml",
+        project_path=None,
+    )
+    assert {entry.tier for entry in catalog} == {"user"}
+
+
+def test_missing_selected_profile_raises_with_source(tmp_path: Path) -> None:
+    catalog = collect_profile_catalog(
+        user_config={"profiles": {"prod": {"general": {"default_mode": "thinking"}}}},
+        project_config={},
+        user_path=tmp_path / "user.toml",
+        project_path=None,
+    )
+    with pytest.raises(ConfigProfileError) as exc:
+        resolve_profile_layer(
+            ProfileSelection("prdo", "flag", "--profile flag"),
+            catalog,
+        )
+    assert "prdo" in exc.value.message
+    assert "--profile flag" in exc.value.message
+    assert "prod" in (exc.value.suggestion or "")
+
+
+@pytest.mark.parametrize(
+    "selection,detail_substring",
+    [
+        (ProfileSelection("ghost", "env", "THOTH_PROFILE"), "THOTH_PROFILE"),
+        (ProfileSelection("ghost", "config", "general.default_profile"), "general.default_profile"),
+    ],
+)
+def test_missing_profile_raises_for_each_selection_source(
+    tmp_path: Path,
+    selection: ProfileSelection,
+    detail_substring: str,
+) -> None:
+    catalog = collect_profile_catalog(
+        user_config={"profiles": {"prod": {"general": {"default_mode": "thinking"}}}},
+        project_config={},
+        user_path=tmp_path / "user.toml",
+        project_path=None,
+    )
+    with pytest.raises(ConfigProfileError) as exc:
+        resolve_profile_layer(selection, catalog)
+    assert detail_substring in exc.value.message

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -261,7 +261,13 @@ default_mode = "thinking"
 
 
 def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
-    """Regression guard: THOTH_PROFILE must not be added to env_mappings."""
+    """Regression guard (structural): THOTH_PROFILE must not be added to env_mappings.
+
+    Brittle under refactor — a future move of env_mappings to a module-level
+    constant would silently bypass this check. See the companion behavioral
+    guard ``test_thoth_profile_does_not_leak_into_env_layer_at_runtime`` for
+    the refactor-safe check (BUG-06).
+    """
     import inspect
 
     from thoth import config as thoth_config
@@ -270,6 +276,25 @@ def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
     assert "THOTH_PROFILE" not in src, (
         "THOTH_PROFILE belongs to Stage 1 selection (read by resolve_profile_selection), "
         "not Stage 2 per-setting overrides. See CPP REQ-CPP-004."
+    )
+
+
+def test_thoth_profile_does_not_leak_into_env_layer_at_runtime(
+    isolated_thoth_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BUG-06 (behavioral): regardless of how env mappings are structured
+    (literal-in-method or module-level constant), setting THOTH_PROFILE in
+    the environment must NOT produce a per-setting override in the env
+    layer. THOTH_PROFILE is a Stage 1 selector (read by
+    ``resolve_profile_selection``), not a Stage 2 per-setting value.
+    """
+    monkeypatch.setenv("THOTH_PROFILE", "ghost-profile")
+    cm = ConfigManager()
+    overrides = cm._get_env_overrides()
+    # The selector value must not appear anywhere in the env-override layer.
+    assert "ghost-profile" not in repr(overrides), (
+        f"THOTH_PROFILE leaked into env overrides as a per-setting value: {overrides!r}"
     )
 
 

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -269,3 +269,41 @@ def test_thoth_profile_is_not_a_per_setting_env_override() -> None:
         "THOTH_PROFILE belongs to Stage 1 selection (read by resolve_profile_selection), "
         "not Stage 2 per-setting overrides. See CPP REQ-CPP-004."
     )
+
+
+from click.testing import CliRunner
+
+from thoth.cli import cli
+
+
+def test_root_profile_reaches_config_get(isolated_thoth_home: Path) -> None:
+    from thoth.paths import user_config_file
+
+    _write(
+        user_config_file(),
+        """
+version = "2.0"
+
+[profiles.fast.general]
+default_mode = "thinking"
+""".strip()
+        + "\n",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--profile", "fast", "config", "get", "general.default_mode"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip().splitlines()[-1] == "thinking"
+
+
+def test_unknown_root_profile_errors_before_config_get(isolated_thoth_home: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["--profile", "missing", "config", "get", "general.default_mode"],
+    )
+
+    assert result.exit_code == 1
+    assert "Profile 'missing' not found" in result.output

--- a/tests/test_config_profiles_permutations.py
+++ b/tests/test_config_profiles_permutations.py
@@ -1,0 +1,329 @@
+"""P21-TS08: permutation matrix over profile selection × tier × prefix × mode.
+
+Axes:
+  - selection_source: flag | env | config-pointer | none
+  - tier:             user | project | both (project shadows)
+  - prefix_present:   yes | no
+  - mode:             deep_research | thinking | default
+
+This file commits real TOML configs (inline strings) per case and asserts
+the final ConfigManager state for each cell of the meaningful cross-product.
+The shipped `init` examples are exercised via `_INIT_EXAMPLE_PROFILES`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from thoth.config import ConfigManager
+from thoth.config_profiles import assemble_prompt_with_prefix, resolve_prompt_prefix
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Selection-source permutations (axis 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_profile_user_config(isolated_thoth_home: Path) -> Path:
+    from thoth.paths import user_config_file
+
+    body = """version = "2.0"
+[general]
+default_mode = "default"
+
+[profiles.fast.general]
+default_mode = "thinking"
+[profiles.fast]
+prompt_prefix = "FAST_PREFIX"
+
+[profiles.deep.general]
+default_mode = "deep_research"
+[profiles.deep]
+prompt_prefix = "DEEP_PREFIX"
+"""
+    _write(user_config_file(), body)
+    return user_config_file()
+
+
+@pytest.mark.parametrize(
+    "source,setup,expected_name,expected_source",
+    [
+        ("flag", {"_profile": "deep"}, "deep", "flag"),
+        ("env", {}, "deep", "env"),
+        ("config-pointer", {}, "fast", "config"),
+        ("none", {}, None, "none"),
+    ],
+)
+def test_selection_source_axis(
+    two_profile_user_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    setup: dict,
+    expected_name: str | None,
+    expected_source: str,
+) -> None:
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+
+    if source == "env":
+        monkeypatch.setenv("THOTH_PROFILE", "deep")
+    elif source == "config-pointer":
+        # Append general.default_profile = "fast" to the existing config.
+        from thoth.paths import user_config_file
+
+        existing = user_config_file().read_text()
+        # Insert into [general] (already has default_mode); append a new key.
+        new = existing.replace(
+            '[general]\ndefault_mode = "default"',
+            '[general]\ndefault_mode = "default"\ndefault_profile = "fast"',
+        )
+        user_config_file().write_text(new)
+
+    cm = ConfigManager()
+    cm.load_all_layers(setup)
+    assert cm.profile_selection.name == expected_name
+    assert cm.profile_selection.source == expected_source
+
+
+# ---------------------------------------------------------------------------
+# Tier permutations (axis 2): user | project | both (project shadows)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tier,user_block,project_block,expected_default_mode,expected_prefix",
+    [
+        # Profile only in user tier
+        (
+            "user",
+            """version = "2.0"
+[profiles.shared.general]
+default_mode = "thinking"
+[profiles.shared]
+prompt_prefix = "USER_PREFIX"
+""",
+            None,
+            "thinking",
+            "USER_PREFIX",
+        ),
+        # Profile only in project tier
+        (
+            "project",
+            'version = "2.0"\n',
+            """version = "2.0"
+[profiles.shared.general]
+default_mode = "deep_research"
+[profiles.shared]
+prompt_prefix = "PROJECT_PREFIX"
+""",
+            "deep_research",
+            "PROJECT_PREFIX",
+        ),
+        # Same-named profile in both tiers — project wholesale shadows user
+        (
+            "both",
+            """version = "2.0"
+[profiles.shared.general]
+default_mode = "thinking"
+[profiles.shared]
+prompt_prefix = "USER_PREFIX"
+""",
+            """version = "2.0"
+[profiles.shared.general]
+default_mode = "deep_research"
+[profiles.shared]
+prompt_prefix = "PROJECT_PREFIX"
+""",
+            "deep_research",
+            "PROJECT_PREFIX",
+        ),
+    ],
+)
+def test_tier_axis(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tier: str,
+    user_block: str,
+    project_block: str | None,
+    expected_default_mode: str,
+    expected_prefix: str,
+) -> None:
+    from thoth.paths import user_config_file
+
+    monkeypatch.delenv("THOTH_PROFILE", raising=False)
+    monkeypatch.chdir(tmp_path)
+    _write(user_config_file(), user_block)
+    if project_block is not None:
+        _write(tmp_path / "thoth.toml", project_block)
+
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "shared"})
+    assert cm.profile_selection.name == "shared"
+    assert cm.get("general.default_mode") == expected_default_mode
+    assert resolve_prompt_prefix(cm, "default") == expected_prefix
+    if tier == "both":
+        # Project tier wins wholesale
+        assert cm.active_profile is not None
+        assert cm.active_profile.tier == "project"
+
+
+# ---------------------------------------------------------------------------
+# Prefix-presence × mode axes (3 × 3)
+# ---------------------------------------------------------------------------
+
+
+_HIERARCHY_CONFIG = """version = "2.0"
+[general]
+prompt_prefix = "GENERAL"
+
+[modes.deep_research]
+prompt_prefix = "MODE_DEEP"
+
+[profiles.alpha]
+prompt_prefix = "PROFILE_ALPHA"
+
+[profiles.alpha.modes.deep_research]
+prompt_prefix = "PROFILE_ALPHA_DEEP"
+"""
+
+
+@pytest.mark.parametrize(
+    "active_profile,mode,expected",
+    [
+        # No active profile → modes.M, then general
+        (None, "deep_research", "MODE_DEEP"),
+        (None, "thinking", "GENERAL"),
+        (None, "default", "GENERAL"),
+        # alpha active: profile.modes.M for deep; profile for others
+        ("alpha", "deep_research", "PROFILE_ALPHA_DEEP"),
+        ("alpha", "thinking", "PROFILE_ALPHA"),
+        ("alpha", "default", "PROFILE_ALPHA"),
+    ],
+)
+def test_prefix_hierarchy_per_mode(
+    isolated_thoth_home: Path,
+    active_profile: str | None,
+    mode: str,
+    expected: str,
+) -> None:
+    from thoth.paths import user_config_file
+
+    _write(user_config_file(), _HIERARCHY_CONFIG)
+    cm = ConfigManager()
+    cli_args: dict[str, object] = {}
+    if active_profile:
+        cli_args["_profile"] = active_profile
+    cm.load_all_layers(cli_args)
+
+    assert resolve_prompt_prefix(cm, mode) == expected
+
+
+# ---------------------------------------------------------------------------
+# Use-case smoke tests — the shipped `init` example profiles, exercised end-to-end.
+# ---------------------------------------------------------------------------
+
+
+_INIT_EXAMPLE_CONFIG = """version = "2.0"
+[general]
+default_mode = "default"
+
+[profiles.daily.general]
+default_mode = "thinking"
+default_project = "daily-notes"
+
+[profiles.openai_deep.general]
+default_mode = "deep_research"
+[profiles.openai_deep.modes.deep_research]
+providers = ["openai"]
+parallel = false
+
+[profiles.all_deep.general]
+default_mode = "deep_research"
+[profiles.all_deep.modes.deep_research]
+providers = ["openai", "perplexity"]
+parallel = true
+
+[profiles.deep_research.general]
+default_mode = "deep_research"
+prompt_prefix = "Be thorough."
+[profiles.deep_research.modes.deep_research]
+providers = ["openai", "perplexity"]
+parallel = true
+prompt_prefix = "Be thorough. Cite primary sources. Include counter-arguments."
+"""
+
+
+@pytest.mark.parametrize(
+    "profile,mode,expected_default_mode,expected_assembled",
+    [
+        (
+            "daily",
+            "thinking",
+            "thinking",
+            "topic",  # no prompt_prefix in daily
+        ),
+        (
+            "openai_deep",
+            "deep_research",
+            "deep_research",
+            "topic",  # no prefix in openai_deep
+        ),
+        (
+            "deep_research",
+            "deep_research",
+            "deep_research",
+            "Be thorough. Cite primary sources. Include counter-arguments.\n\ntopic",
+        ),
+        (
+            "deep_research",
+            "thinking",
+            "deep_research",
+            "Be thorough.\n\ntopic",
+        ),
+    ],
+)
+def test_shipped_examples_assemble_correctly(
+    isolated_thoth_home: Path,
+    profile: str,
+    mode: str,
+    expected_default_mode: str,
+    expected_assembled: str,
+) -> None:
+    from thoth.paths import user_config_file
+
+    _write(user_config_file(), _INIT_EXAMPLE_CONFIG)
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": profile})
+    assert cm.get("general.default_mode") == expected_default_mode
+    assert assemble_prompt_with_prefix(cm, mode, "topic") == expected_assembled
+
+
+# ---------------------------------------------------------------------------
+# Negative cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_profile_active_ignores_profile_levels(isolated_thoth_home: Path) -> None:
+    """When no profile is active, prefix from profile-only config returns None."""
+    from thoth.paths import user_config_file
+
+    _write(
+        user_config_file(),
+        """version = "2.0"
+[profiles.unused]
+prompt_prefix = "UNUSED"
+""",
+    )
+    cm = ConfigManager()
+    cm.load_all_layers({})
+    assert cm.profile_selection.name is None
+    assert resolve_prompt_prefix(cm, "default") is None
+    assert assemble_prompt_with_prefix(cm, "default", "x") == "x"

--- a/tests/test_config_prompt_prefix.py
+++ b/tests/test_config_prompt_prefix.py
@@ -1,0 +1,186 @@
+"""P21-TS07: hierarchy tests for resolve_prompt_prefix.
+
+Resolution order (most-specific first):
+  1. profiles.<active>.modes.<MODE>.prompt_prefix
+  2. profiles.<active>.prompt_prefix
+  3. modes.<MODE>.prompt_prefix
+  4. general.prompt_prefix
+  5. None
+
+More-specific REPLACES less-specific — no concatenation.
+Empty string is treated as "unset" so a level can't accidentally erase outer values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from thoth.config import ConfigManager
+from thoth.config_profiles import resolve_prompt_prefix
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _cm(isolated: Path, body: str, *, profile: str | None = None) -> ConfigManager:
+    from thoth.paths import user_config_file
+
+    _write(user_config_file(), body)
+    cm = ConfigManager()
+    cli_args: dict[str, object] = {}
+    if profile:
+        cli_args["_profile"] = profile
+    cm.load_all_layers(cli_args)
+    return cm
+
+
+def test_no_prefix_anywhere_returns_none(isolated_thoth_home: Path) -> None:
+    cm = _cm(isolated_thoth_home, 'version = "2.0"\n')
+    assert resolve_prompt_prefix(cm, "default") is None
+
+
+def test_general_prompt_prefix_applies_when_no_other_levels(
+    isolated_thoth_home: Path,
+) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        'version = "2.0"\n[general]\nprompt_prefix = "GLOBAL"\n',
+    )
+    assert resolve_prompt_prefix(cm, "default") == "GLOBAL"
+
+
+def test_modes_prefix_overrides_general(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[modes.deep_research]
+prompt_prefix = "MODE"
+""",
+    )
+    assert resolve_prompt_prefix(cm, "deep_research") == "MODE"
+    # Other modes still get general
+    assert resolve_prompt_prefix(cm, "default") == "GLOBAL"
+
+
+def test_profile_prefix_overrides_modes_and_general(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[modes.deep_research]
+prompt_prefix = "MODE"
+
+[profiles.fast]
+prompt_prefix = "PROFILE"
+""",
+        profile="fast",
+    )
+    assert resolve_prompt_prefix(cm, "deep_research") == "PROFILE"
+    assert resolve_prompt_prefix(cm, "default") == "PROFILE"
+
+
+def test_profile_modes_prefix_is_most_specific(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[modes.deep_research]
+prompt_prefix = "MODE"
+
+[profiles.fast]
+prompt_prefix = "PROFILE"
+
+[profiles.fast.modes.deep_research]
+prompt_prefix = "PROFILE_MODE"
+""",
+        profile="fast",
+    )
+    assert resolve_prompt_prefix(cm, "deep_research") == "PROFILE_MODE"
+    # default mode falls back to PROFILE
+    assert resolve_prompt_prefix(cm, "default") == "PROFILE"
+
+
+def test_no_active_profile_skips_profile_levels(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[profiles.fast]
+prompt_prefix = "PROFILE"
+""",
+    )
+    # No --profile / THOTH_PROFILE / default_profile, so profile is not active
+    assert cm.profile_selection.name is None
+    assert resolve_prompt_prefix(cm, "default") == "GLOBAL"
+
+
+def test_empty_string_is_treated_as_unset(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[profiles.fast]
+prompt_prefix = ""
+""",
+        profile="fast",
+    )
+    # Empty string at profile level should NOT override; falls through to general
+    assert resolve_prompt_prefix(cm, "default") == "GLOBAL"
+
+
+def test_replace_semantics_no_concatenation(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "OUTER"
+
+[profiles.fast]
+prompt_prefix = "INNER"
+""",
+        profile="fast",
+    )
+    # Result is exactly INNER, not "OUTER\n\nINNER"
+    result = resolve_prompt_prefix(cm, "default")
+    assert result == "INNER"
+    assert "OUTER" not in (result or "")
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("deep_research", "PROFILE_MODE"),
+        ("thinking", "PROFILE"),
+        ("default", "PROFILE"),
+    ],
+)
+def test_resolution_per_mode(
+    isolated_thoth_home: Path, mode: str, expected: str
+) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[profiles.fast]
+prompt_prefix = "PROFILE"
+
+[profiles.fast.modes.deep_research]
+prompt_prefix = "PROFILE_MODE"
+""",
+        profile="fast",
+    )
+    assert resolve_prompt_prefix(cm, mode) == expected

--- a/tests/test_config_prompt_prefix.py
+++ b/tests/test_config_prompt_prefix.py
@@ -169,9 +169,7 @@ prompt_prefix = "INNER"
         ("default", "PROFILE"),
     ],
 )
-def test_resolution_per_mode(
-    isolated_thoth_home: Path, mode: str, expected: str
-) -> None:
+def test_resolution_per_mode(isolated_thoth_home: Path, mode: str, expected: str) -> None:
     cm = _cm(
         isolated_thoth_home,
         """version = "2.0"

--- a/tests/test_init_ships_profiles.py
+++ b/tests/test_init_ships_profiles.py
@@ -14,10 +14,19 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
 from thoth.commands import CommandHandler
 from thoth.config import ConfigManager
 from thoth.config_profiles import resolve_prompt_prefix
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep CLI --config tests from leaking into later tests."""
+    from thoth import config as thoth_config
+
+    monkeypatch.setattr(thoth_config, "_config_path", None)
 
 
 @pytest.fixture
@@ -89,3 +98,43 @@ def test_deep_research_profile_carries_prompt_prefix(init_run: Path) -> None:
     prefix = resolve_prompt_prefix(cm, "deep_research")
     assert prefix is not None
     assert len(prefix) > 0
+
+
+def test_cli_init_custom_config_path_writes_starter_profiles(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    from thoth.cli import cli
+
+    target = tmp_path / "custom-thoth.toml"
+    result = CliRunner().invoke(cli, ["--config", str(target), "init"])
+
+    assert result.exit_code == 0, result.output
+    assert target.exists()
+    text = target.read_text()
+    assert "[profiles.daily.general]" in text
+    assert "[profiles.deep_research.modes.deep_research]" in text
+
+
+def test_cli_init_json_non_interactive_writes_starter_profiles(
+    isolated_thoth_home: Path,
+    tmp_path: Path,
+) -> None:
+    import json
+
+    from thoth.cli import cli
+
+    target = tmp_path / "json-thoth.toml"
+    result = CliRunner().invoke(
+        cli,
+        ["--config", str(target), "init", "--json", "--non-interactive"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["data"]["created"] is True
+    text = target.read_text()
+    assert "[profiles.daily.general]" in text
+    assert "[profiles.deep_research.modes.deep_research]" in text

--- a/tests/test_init_ships_profiles.py
+++ b/tests/test_init_ships_profiles.py
@@ -1,0 +1,91 @@
+"""P21-T10: `thoth init` ships example profiles users can customize.
+
+The generated `~/.config/thoth/config.toml` should contain:
+  - daily          — thinking + default project for daily notes
+  - quick          — thinking (immediate)
+  - openai_deep    — single-provider deep_research
+  - all_deep       — parallel openai+perplexity deep_research
+  - interactive    — interactive default mode
+  - deep_research  — deep_research with a `prompt_prefix` example
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from thoth.commands import CommandHandler
+from thoth.config import ConfigManager
+from thoth.config_profiles import resolve_prompt_prefix
+
+
+@pytest.fixture
+def init_run(isolated_thoth_home: Path) -> Path:
+    """Run init_command against the isolated XDG config dir, return config path."""
+    from thoth.paths import user_config_file
+
+    handler = CommandHandler(ConfigManager())
+    handler.init_command()
+    path = user_config_file()
+    assert path.exists(), f"init did not create config at {path}"
+    return path
+
+
+def test_init_writes_parseable_config(init_run: Path) -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({})
+    # Every shipped profile should be in the catalog.
+    names = {entry.name for entry in cm.profile_catalog}
+    assert {
+        "daily",
+        "quick",
+        "openai_deep",
+        "all_deep",
+        "interactive",
+        "deep_research",
+    }.issubset(names)
+
+
+@pytest.mark.parametrize(
+    "profile_name,expected_default_mode",
+    [
+        ("daily", "thinking"),
+        ("quick", "thinking"),
+        ("openai_deep", "deep_research"),
+        ("all_deep", "deep_research"),
+        ("interactive", "interactive"),
+        ("deep_research", "deep_research"),
+    ],
+)
+def test_each_shipped_profile_sets_expected_default_mode(
+    init_run: Path, profile_name: str, expected_default_mode: str
+) -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": profile_name})
+    assert cm.profile_selection.name == profile_name
+    assert cm.get("general.default_mode") == expected_default_mode
+
+
+def test_openai_deep_profile_uses_single_provider(init_run: Path) -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "openai_deep"})
+    deep = cm.data["modes"]["deep_research"]
+    assert deep.get("providers") == ["openai"]
+    assert deep.get("parallel") is False
+
+
+def test_all_deep_profile_uses_parallel_providers(init_run: Path) -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "all_deep"})
+    deep = cm.data["modes"]["deep_research"]
+    assert deep.get("providers") == ["openai", "perplexity"]
+    assert deep.get("parallel") is True
+
+
+def test_deep_research_profile_carries_prompt_prefix(init_run: Path) -> None:
+    cm = ConfigManager()
+    cm.load_all_layers({"_profile": "deep_research"})
+    prefix = resolve_prompt_prefix(cm, "deep_research")
+    assert prefix is not None
+    assert len(prefix) > 0

--- a/tests/test_init_ships_profiles.py
+++ b/tests/test_init_ships_profiles.py
@@ -100,6 +100,28 @@ def test_deep_research_profile_carries_prompt_prefix(init_run: Path) -> None:
     assert len(prefix) > 0
 
 
+def test_build_profile_section_preserves_sibling_subsections() -> None:
+    """C14: siblings sharing a prefix (e.g., modes.deep_research + modes.thinking)
+    must coexist under the same intermediate table, not overwrite each other."""
+    from thoth.commands import _build_profile_section
+
+    body = {
+        "modes.deep_research": {"providers": ["openai"], "parallel": False},
+        "modes.thinking": {"prompt_prefix": "Think hard."},
+    }
+    table = _build_profile_section(body)
+    modes = table.get("modes")
+    assert modes is not None, "modes intermediate table missing"
+    assert "deep_research" in modes, (
+        f"deep_research silently dropped; modes keys = {list(modes.keys())}"
+    )
+    assert "thinking" in modes, f"thinking silently dropped; modes keys = {list(modes.keys())}"
+    # Full content must round-trip — not just keys
+    assert modes["deep_research"]["providers"] == ["openai"]
+    assert modes["deep_research"]["parallel"] is False
+    assert modes["thinking"]["prompt_prefix"] == "Think hard."
+
+
 def test_cli_init_custom_config_path_writes_starter_profiles(
     isolated_thoth_home: Path,
     tmp_path: Path,

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -68,6 +68,66 @@ def test_basic_interactive_mode_stores_last_operation_id(
     assert observed["kwargs"]["prompt"] == "interactive stored op id"
 
 
+def test_basic_interactive_mode_threads_profile_to_run_research(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BUG-02: --profile passed to enter_interactive_mode reaches both
+    get_config (so profile-aware overlays are applied during interactive
+    setup) and run_research (so the profile is honored on each prompt)."""
+    observed: dict[str, Any] = {}
+    get_config_calls: list[str | None] = []
+
+    async def fake_run_research(**kwargs: Any) -> str:
+        observed["kwargs"] = kwargs
+        return "research-20260416-020202-fedcba9876543210"
+
+    def fake_get_config(profile: str | None = None) -> Any:
+        get_config_calls.append(profile)
+        # Return a minimal stand-in with the attribute access the basic-input
+        # branch makes: config.data["general"].get("default_mode", ...).
+        from thoth.config import ConfigManager
+
+        cm = ConfigManager.__new__(ConfigManager)
+        cm.data = {"general": {"default_mode": "default"}}
+        return cm
+
+    prompts = iter(["profile reaches run_research"])
+
+    def fake_input(prompt: object = "") -> str:
+        try:
+            return next(prompts)
+        except StopIteration as exc:
+            raise EOFError("no more inputs") from exc
+
+    import thoth.interactive as _interactive
+
+    monkeypatch.setattr(thoth_main, "PROMPT_TOOLKIT_AVAILABLE", False)
+    monkeypatch.setattr(thoth_main, "run_research", cast(Any, fake_run_research))
+    monkeypatch.setattr(_interactive, "get_config", cast(Any, fake_get_config))
+    monkeypatch.setattr(builtins, "input", cast(Any, fake_input))
+
+    asyncio.run(
+        thoth_main.enter_interactive_mode(
+            initial_settings=thoth_main.InteractiveInitialSettings(provider="mock"),
+            project=None,
+            output_dir=None,
+            config_path=None,
+            verbose=False,
+            quiet=True,
+            no_metadata=False,
+            timeout=None,
+            profile="fast",
+        )
+    )
+
+    assert get_config_calls == ["fast"], (
+        f"expected get_config called once with profile='fast', got: {get_config_calls!r}"
+    )
+    assert observed["kwargs"].get("profile") == "fast", (
+        f"expected profile='fast' to reach run_research, got: {observed['kwargs'].get('profile')!r}"
+    )
+
+
 def test_slash_status_delegates_to_show_status(monkeypatch: pytest.MonkeyPatch) -> None:
     """P07-M3-02: prompt-toolkit /status delegates to show_status for the last operation."""
     if not getattr(thoth_main, "PROMPT_TOOLKIT_AVAILABLE", False):

--- a/tests/test_p16_pr2_options_decorator.py
+++ b/tests/test_p16_pr2_options_decorator.py
@@ -10,9 +10,9 @@ from thoth.cli_subcommands._options import _RESEARCH_OPTIONS, _research_options
 
 def test_research_options_decorator_adds_all_research_flags():
     # Catches accidental additions/removals in _RESEARCH_OPTIONS.
-    # P18 Phase E added --out (repeatable) and --append; flag count is 23.
-    assert len(_RESEARCH_OPTIONS) == 23, (
-        f"expected 23 research-options entries (21 from PR2 + 2 from P18), "
+    # P18 Phase E added --out (repeatable) and --append; P21 added --profile.
+    assert len(_RESEARCH_OPTIONS) == 24, (
+        f"expected 24 research-options entries (21 from PR2 + 2 from P18 + 1 from P21), "
         f"got {len(_RESEARCH_OPTIONS)}"
     )
 

--- a/tests/test_p16_thothgroup.py
+++ b/tests/test_p16_thothgroup.py
@@ -173,10 +173,12 @@ def test_providers_list_invokes_correct_function(monkeypatch):
         filter_provider=None,
         refresh_cache=False,
         no_cache=False,
+        profile=None,
     ):
         called["invoked"] = True
         called["show_list"] = show_list
         called["filter_provider"] = filter_provider
+        called["profile"] = profile
         return None
 
     monkeypatch.setattr("thoth.commands.providers_command", fake_command)
@@ -186,6 +188,7 @@ def test_providers_list_invokes_correct_function(monkeypatch):
     assert called["invoked"] is True
     assert called["show_list"] is True
     assert called["filter_provider"] is None
+    assert called["profile"] is None
 
 
 def test_config_subgroup_registered():

--- a/tests/test_p16_thothgroup.py
+++ b/tests/test_p16_thothgroup.py
@@ -200,7 +200,7 @@ def test_config_list_invokes_handler(monkeypatch):
 
     called = {}
 
-    def fake_config_command(op, rest):
+    def fake_config_command(op, rest, **kwargs):
         called["op"] = op
         called["rest"] = rest
         return 0

--- a/tests/test_run_prompt_prefix.py
+++ b/tests/test_run_prompt_prefix.py
@@ -1,0 +1,108 @@
+"""P21-TS09: integration — prompt_prefix wiring into the prompt assembly.
+
+These tests exercise the assembly helper that `run_research` calls. They
+cover:
+  - When a prefix resolves, the assembled prompt is f"{prefix}\\n\\n{user_prompt}".
+  - When no prefix resolves, the prompt is unchanged (no leading whitespace).
+  - The mode's `system_prompt` is independent of the prefix path.
+
+The full run_research call is exercised by the thoth_test integration suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from thoth.config import ConfigManager
+from thoth.config_profiles import assemble_prompt_with_prefix
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _cm(isolated: Path, body: str, *, profile: str | None = None) -> ConfigManager:
+    from thoth.paths import user_config_file
+
+    _write(user_config_file(), body)
+    cm = ConfigManager()
+    cli_args: dict[str, object] = {}
+    if profile:
+        cli_args["_profile"] = profile
+    cm.load_all_layers(cli_args)
+    return cm
+
+
+def test_no_prefix_returns_prompt_unchanged(isolated_thoth_home: Path) -> None:
+    cm = _cm(isolated_thoth_home, 'version = "2.0"\n')
+    result = assemble_prompt_with_prefix(cm, "default", "hello world")
+    assert result == "hello world"
+
+
+def test_general_prefix_prepended_with_blank_line(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        'version = "2.0"\n[general]\nprompt_prefix = "Be thorough."\n',
+    )
+    result = assemble_prompt_with_prefix(cm, "default", "research vector dbs")
+    assert result == "Be thorough.\n\nresearch vector dbs"
+
+
+def test_active_profile_prefix_replaces_general(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[general]
+prompt_prefix = "GLOBAL"
+
+[profiles.deep]
+prompt_prefix = "Cite primary sources."
+""",
+        profile="deep",
+    )
+    result = assemble_prompt_with_prefix(cm, "deep_research", "compare X and Y")
+    assert result == "Cite primary sources.\n\ncompare X and Y"
+    assert "GLOBAL" not in result
+
+
+def test_profile_mode_specific_prefix_wins(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        """version = "2.0"
+[profiles.deep]
+prompt_prefix = "GENERAL_PROFILE"
+
+[profiles.deep.modes.deep_research]
+prompt_prefix = "DEEP_RESEARCH_ONLY"
+""",
+        profile="deep",
+    )
+    deep = assemble_prompt_with_prefix(cm, "deep_research", "topic")
+    other = assemble_prompt_with_prefix(cm, "thinking", "topic")
+    assert deep == "DEEP_RESEARCH_ONLY\n\ntopic"
+    assert other == "GENERAL_PROFILE\n\ntopic"
+
+
+def test_empty_user_prompt_still_assembles(isolated_thoth_home: Path) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        'version = "2.0"\n[general]\nprompt_prefix = "PREFIX"\n',
+    )
+    # Edge case: empty user prompt. Caller's responsibility to validate
+    # non-empty prompts; this helper just assembles what it's given.
+    assert assemble_prompt_with_prefix(cm, "default", "") == "PREFIX\n\n"
+
+
+@pytest.mark.parametrize("user_prompt", ["short", "multi\nline\nprompt", "  whitespace  "])
+def test_user_prompt_preserved_verbatim(
+    isolated_thoth_home: Path, user_prompt: str
+) -> None:
+    cm = _cm(
+        isolated_thoth_home,
+        'version = "2.0"\n[general]\nprompt_prefix = "PREFIX"\n',
+    )
+    result = assemble_prompt_with_prefix(cm, "default", user_prompt)
+    assert result == f"PREFIX\n\n{user_prompt}"

--- a/tests/test_run_prompt_prefix.py
+++ b/tests/test_run_prompt_prefix.py
@@ -97,9 +97,7 @@ def test_empty_user_prompt_still_assembles(isolated_thoth_home: Path) -> None:
 
 
 @pytest.mark.parametrize("user_prompt", ["short", "multi\nline\nprompt", "  whitespace  "])
-def test_user_prompt_preserved_verbatim(
-    isolated_thoth_home: Path, user_prompt: str
-) -> None:
+def test_user_prompt_preserved_verbatim(isolated_thoth_home: Path, user_prompt: str) -> None:
     cm = _cm(
         isolated_thoth_home,
         'version = "2.0"\n[general]\nprompt_prefix = "PREFIX"\n',


### PR DESCRIPTION
## Summary

Lands P21 — CPP-style configuration profiles for thoth.

- **Selection & overlay**: root `--profile NAME`, `THOTH_PROFILE`, and `general.default_profile` resolve a single active `[profiles.<name>]` table that overlays project config, between project and env/CLI per-setting overrides. Missing profiles hard-error and name the source.
- **`prompt_prefix` 4-level hierarchy**: `[profiles.X.modes.M]` > `[profiles.X]` > `[modes.M]` > `[general]`. More-specific replaces. The resolved prefix is prepended to the user prompt at `run_research` entry; the mode's `system_prompt` is unchanged.
- **`thoth init` ships starter profiles**: `daily`, `quick`, `openai_deep`, `all_deep`, `interactive`, and `deep_research` (the last demonstrates the prefix hierarchy). Init writer rebuilt on tomlkit for syntactic safety.
- **Permutation test matrix**: covers selection-source × tier × prefix-presence × mode, including the shipped examples.
- **Future work logged**: P33 (Schema-Driven Config Defaults) added to `PROJECTS.md` as the next step beyond P21's tomlkit refactor.

## Test plan

- [x] `just check` — ruff + ty on `src/thoth/` clean
- [x] `uv run pytest -q` — 691 passed, 0 failed (added 64 new tests across 4 files)
- [x] `./thoth_test -r --skip-interactive -q` — 76 passed, 0 failed
- [x] `just test-lint` and `just test-typecheck` — clean
- [x] `git diff --check` — no whitespace errors
- [ ] Manual: hand-edit a profile, verify `--profile`, `THOTH_PROFILE`, and `general.default_profile` precedence
- [ ] Manual: run `thoth init` in a fresh XDG home; confirm shipped profiles parse and `--profile deep_research` applies the prompt prefix