### PR TITLE
docs(projects): capture P39 — Pluggy-based plugin system idea

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -72,6 +72,7 @@ Older entries may use `**Primary spec**`, `**Plan**`, or
 <!-- Descending P-number order. Scoped / in-progress / done first;
      ideas last. One row per file; one file per row. -->
 
+- [?] **P39** — [Pluggy-Based Plugin System for Providers & Commands](projects/P39-pluggy-plugin-system-.md)
 - [ ] **P38** — [Perplexity Sync VCR Replay](projects/P38-perplexity-sync-vcr-replay.md)
 - [?] **P37** — [Review starter-profile selection](projects/P37-starter-profile-review-.md)
 - [x] **P36** — [Uniform `--help` + Useful API-Key Errors](projects/P36-help-uniform-errors.md)

--- a/projects/P39-pluggy-plugin-system-.md
+++ b/projects/P39-pluggy-plugin-system-.md
@@ -1,0 +1,17 @@
+# P39 — Pluggy-Based Plugin System for Providers & Commands
+
+Pluggy-based plugin discovery so external packages extend providers and commands.
+
+### Open questions
+- Q: What hook specs should we expose? (register provider, register command, configuration hooks?)
+- Q: Where does plugin discovery happen — at startup or lazily on first use?
+- Q: How do plugin-contributed config keys merge with P33's schema-driven defaults?
+- Q: Trust model — how do we handle untrusted third-party plugins?
+
+### Notes
+- Design inspiration: Simon Willison's [`llm`](https://github.com/simonw/llm) — Pluggy-based plugin architecture, setuptools entry points, plugin hook groups. Study its hook specs and plugin-discovery patterns when scoping.
+- Plugins should be able to hook into thoth's configuration (extend schema, add defaults, override resolution) — study how `llm` exposes config to its plugins for inspiration.
+- Reuses thoth's existing provider registry from [P09](P09-decompose-main-appcontext-di.md) and schema-driven config defaults from [P33](P33-schema-driven-config-defaults.md).
+
+<!-- Idea state. Minimal by convention.
+     Promote with `project-refine P39` when ready. -->


### PR DESCRIPTION
## Summary
- Capture **P39 — Pluggy-Based Plugin System for Providers & Commands** as a `[?]` idea on the project trunk
- Records design inspiration from [Simon Willison's `llm`](https://github.com/simonw/llm) (Pluggy + setuptools entry points) and the goal of letting plugins hook into thoth's configuration
- Notes reuse of existing provider registry (P09) and schema-driven config defaults (P33), with four open design questions to resolve in `project-refine`

## Test plan
- [ ] `PROJECTS.md` shows the new `[?] **P39**` row at the top of the project index
- [ ] `projects/P39-pluggy-plugin-system-.md` has trailing-hyphen filename (idea convention) and renders cleanly on GitHub
- [ ] All four open questions are present and the GitHub URL for `simonw/llm` is captured in notes