### PR TITLE
ci: harden all 7 workflows with explicit permissions + concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: [main]
 
+# Explicit minimal permissions; the repo's default is already "read" but
+# pinning here makes the workflow's security posture self-evident from
+# this file alone (independent of repo-level settings).
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,17 @@ on:
   schedule:
     - cron: "10 20 * * 4" # Thursdays 20:10 UTC
 
+# Deny-all at top level; per-job permissions re-grant exactly what's needed.
+# A new job added later without thinking won't accidentally inherit broad
+# perms.
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  # Don't cancel an in-flight scan — partial security results are worse
+  # than slightly-delayed full ones.
+  cancel-in-progress: false
+
 jobs:
   analyze:
     name: Analyze (Python)

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,11 +5,22 @@ on:
   pull_request:
     branches: [main]
 
+# commitlint just reads PR commits; no writes needed.
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  # Cancel stale runs when a PR is force-pushed (saves 2-3 redundant runs
+  # per push-iteration).
+  group: commitlint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -17,10 +17,20 @@ name: Extended Contract Tests (nightly)
 permissions:
   contents: read
 
+concurrency:
+  group: extended
+  # Don't cancel an in-flight nightly — half-finished real-API runs pollute
+  # the test report and burn API quota for no gain.
+  cancel-in-progress: false
+
 jobs:
   extended:
     name: pytest -m "extended and not extended_slow"
     runs-on: ubuntu-latest
+    # Only run live-provider scheduled/manual jobs in the canonical repo.
+    # Forks do not receive upstream secrets, and these tests can spend
+    # provider quota.
+    if: github.repository == 'smorin/doxa-research'
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/live-api.yml
+++ b/.github/workflows/live-api.yml
@@ -24,10 +24,19 @@ name: Live-API Workflow Tests (weekly)
 permissions:
   contents: read
 
+concurrency:
+  group: live-api
+  # Don't cancel an in-flight weekly — same reasoning as extended.yml.
+  cancel-in-progress: false
+
 jobs:
   live_api:
     name: pytest -m "live_api and not extended_slow"
     runs-on: ubuntu-latest
+    # Only run live-provider scheduled/manual jobs in the canonical repo.
+    # Forks do not receive upstream secrets, and these tests can spend
+    # provider quota.
+    if: github.repository == 'smorin/doxa-research'
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,19 @@ on:
     tags:
       - "v*"
 
+# Deny-all at top level; per-job permissions re-grant exactly what's needed.
+# This is the most security-sensitive workflow in the repo (it talks to PyPI),
+# so any new step or job added later requires an explicit grant.
+permissions: {}
+
+concurrency:
+  # Serialize publish runs per tag. If a tag is ever re-pushed (delete + recreate),
+  # the second run waits for the first to finish instead of racing it.
+  group: publish-${{ github.ref }}
+  # NEVER cancel an in-flight publish — a mid-upload abort can leave half-uploaded
+  # state on PyPI (rare but the registries lock filenames on first byte).
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build distribution

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,26 @@ on:
   push:
     branches: [main]
 
+# Deny all GITHUB_TOKEN permissions at top level; per-job permissions
+# re-grant only what's needed. Mutating release work uses the GitHub App
+# token minted inside each job, not the default GITHUB_TOKEN.
+permissions: {}
+
+concurrency:
+  # Serialize per-ref runs. Rapid push sequences on main (which we hit
+  # during the doxa-research rename session) can fire multiple
+  # release-please runs that step on each other when updating the
+  # Release PR. Don't cancel in-flight runs — release-please's PR-update
+  # is incremental and a cancelled half-update can leave the PR
+  # inconsistent.
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # actual write goes via App token below
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# gitleaks finding fingerprints to ignore.
+# Format: <commit-sha>:<path>:<rule-id>:<line>
+# https://github.com/gitleaks/gitleaks#additional-configuration
+
+# RELEASE-PLEASE-APP.md documentation example showing the SHAPE of a PEM-
+# encoded RSA private key file. The placeholder content
+# (`MIIEpAIBAAKCAQEA...lots of base64...`) matches gitleaks' private-key
+# regex by structure, not by content. The doc was rewritten in a follow-up
+# commit to use prose instead of a code block; this entry whitelists the
+# historical finding so full-history scans don't trip on it.
+abb0742ed1a370dfb8381ac0f2166a91dd7028d4:RELEASE-PLEASE-APP.md:private-key:147

--- a/RELEASE-PLEASE-APP.md
+++ b/RELEASE-PLEASE-APP.md
@@ -141,15 +141,9 @@ A `.pem` file downloads to your browser, named like `smorin-release-please.YYYY-
 
 **Treat this file as a credential.** Anyone with its contents can act as the App.
 
-Open the file in a text editor. It contains:
+Open the file in a text editor. It is a standard PEM-encoded RSA private key — a header line, then many lines of base64-encoded key data, then a matching footer line.
 
-```
------BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA...lots of base64...
------END RSA PRIVATE KEY-----
-```
-
-You'll paste this entire content into the per-repo secret in the next phase.
+You'll paste the entire file contents (header, body, and footer) into the per-repo secret in the next phase.
 
 After you've stored it in GitHub Secrets for each repo, delete the local file:
 


### PR DESCRIPTION
## Summary

Applies workflow security improvements proposed in the recent session audit. All 7 workflow files now have:

- **Explicit top-level \`permissions:\`** (either \`{}\` deny-all or \`contents: read\` per workflow) — independent of repo-level "Workflow permissions" setting (defense in depth).
- **Concurrency groups** to prevent parallel-run races, with \`cancel-in-progress\` set per workflow's safety requirements.
- **Fork guards** (\`if: github.repository == 'smorin/doxa-research'\`) on scheduled real-API workflows so forks don't burn API quota with our cron.

Plus a chore commit to whitelist a pre-existing gitleaks false-positive in RELEASE-PLEASE-APP.md (the doc example showing what a PEM private key looks like was matching gitleaks' private-key regex by structure).

See commit messages for full per-workflow details.

## Test plan

This PR exists primarily to TEST the workflow changes via the events they fire on:

| Phase | Verification |
|---|---|
| ✅ Phase 1 (pre-flight) | yamllint, actionlint, YAML parse, runtime commands all green locally |
| 🔄 Phase 2 (this PR) | ci.yml, codeql.yml, commitlint.yml run on the PR event |
| ⏳ Phase 3 (after merge) | ci.yml, codeql.yml, release-please.yml run on push-to-main |
| ⏳ Phase 4 (manual) | \`gh workflow run\` extended.yml and live-api.yml |
| ⏳ Phase 5a (security validation) | tag a non-main commit; new \`verify tag is on main\` check should fail it |
| ⏳ Phase 5b (real release) | merge the release-please Release PR; full publish.yml → PyPI |

## Risk

LOW. Local repo permissions setting is already "read" so the explicit \`permissions:\` declarations are documentation, not behavioral change. Concurrency adds determinism; nothing that worked before should fail. Fork guards close an attack surface that doesn't exist today but would matter if the repo gains forks.

Behavioral changes at runtime:
- Scheduled extended/live-api on a fork would skip the job (intended)
- Two simultaneous publish triggers on the same tag would serialize instead of race (intended)
- A force-pushed PR no longer keeps the prior commitlint run in-flight; the new run cancels the old (intended)