### PR TITLE
docs(claude-md): 4 sub-CLAUDE.md files capturing conventions from recent project work

### DIFF
--- a/docs/superpowers/plans/CLAUDE.md
+++ b/docs/superpowers/plans/CLAUDE.md
@@ -1,0 +1,126 @@
+# Plan-writing conventions
+
+Plans live at `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`. Created
+via `superpowers:writing-plans`, executed via `superpowers:executing-plans`
+or `superpowers:subagent-driven-development`.
+
+## Required header
+
+Every plan opens with this banner so executor agents pick the right
+sub-skill:
+
+```markdown
+# <Feature> Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [one sentence]
+**Architecture:** [2-3 sentences]
+**Tech Stack:** [...]
+**Spec:** projects/P<NN>-<slug>.md
+```
+
+## Cross-reference tasks by stable NAME, not by number
+
+When the plan grows by inserting tasks (spike-driven corrections,
+quality-review fixes), task numbers shift. References like
+`"Implemented in Task 5"` become wrong.
+
+```markdown
+# BAD — breaks on renumber
+"...as confirmed in Task 5..."
+
+# GOOD — stable across renumbers
+"...as confirmed in the `_deep_research_submit` task..."
+"...see the cancel-spike task..."
+```
+
+If you must use numbers (e.g. in stub `NotImplementedError` messages),
+keep them in ONE place (the stub) and update them deliberately during
+renumber. Don't sprinkle the number across multiple bullet points
+in the plan body.
+
+## Renumbering with care
+
+If a plan needs renumbering (e.g. inserting a new Task 2):
+
+```bash
+perl -pi -e 's/\bTask (\d+)\b/$1>=2 && $1<=25 ? "Task " . ($1+1) : "Task $1"/ge' plan.md
+```
+
+The `\b` word boundaries and the conditional range prevent collisions
+(e.g. "Task 25" → "Task 26" before "Task 2" → "Task 3"). After
+renumbering, verify cross-refs in:
+
+- Section headers (`### Task N:`)
+- Body prose ("filled in by Task N")
+- Code blocks (especially stub NotImplementedError messages)
+- Commit-message templates inside the plan
+- File-structure tables (e.g. "created in Task N")
+
+## Spike-driven corrections
+
+When a Task-1 spike reveals plan assumptions were wrong, add a
+`**Spike-driven correction (DATE):**` callout INSIDE each affected
+task — don't rely solely on the refresh-log at the top. Executors
+read tasks one at a time and may miss top-of-file context.
+
+```markdown
+### Task 5: _deep_research_submit — failing tests + implementation
+
+**Spike-driven correction (2026-05-12):** the assumed `agent=` parameter
+was confirmed live. The request shape includes `store=True` (required
+when `background=True`). See `research/spike-2026-05-11.md` §2.
+
+**Files:**
+- ...
+```
+
+## Commit-message embedding (commitlint footer traps)
+
+Plans often include commit-message templates inside `git commit -m "..."`
+fences. These messages, when committed, must pass commitlint. Two
+parser surprises seen in this repo:
+
+| Pattern | What commitlint does | Fix |
+|---|---|---|
+| `Open Question #6.` in body | `#6` matches the issue-reference trailer regex; body line ending with the trailer-like token triggers `footer-leading-blank` | Spell out: `Open Question 6` / `OQ6` / `Q.6` |
+| Body line ending in `:` followed by a paragraph | Trailing colon is read as a footer-token separator; next paragraph parsed as a malformed footer | Reword so no body line ends with `:` (or end the body before the paragraph break) |
+
+Pre-test commit messages locally with `bunx commitlint` (the lefthook
+hook does this on every commit) BEFORE pasting them into a plan
+template — otherwise reviewers will hit the failure on PR CI.
+
+## Avoid bypass flags in plan-templated commits
+
+Plan templates should NOT include `--no-verify` or `LEFTHOOK=0`. Per
+the root `CLAUDE.md` Hook Discipline section: bypass is reserved for
+short-lived intermediate WIP commits the author plans to squash.
+Plan-templated commits are not WIP — they're the actual deliverable.
+
+## Allowed commit types
+
+Conventional Commits enforced by commitlint. The allowed `type` values:
+
+```
+feat, fix, perf, refactor, docs, test, ci, chore, build, style, revert
+```
+
+Not allowed: `spike`, `wip`, `update`, `improve`, etc. Spike commits
+use `chore(<scope>):`. Plan-doc commits use `docs(<scope>):`.
+
+## Subject length
+
+100 characters MAX. Header-only — body is unbounded. Plans should
+template subjects ≤ 80 chars to leave room for scope-prefix length.
+
+## Plan refresh vs new dated file
+
+| When | What |
+|---|---|
+| Small edits (< 30% of tasks change) | In-place refresh; add an `**Updated YYYY-MM-DD:**` log line under the header. |
+| Large rewrites (>= 30% of tasks change) | Archive the old plan to `archive/`, write a new dated plan. Update the project file's "Plan" reference. |
+
+See the P28 v1 → v2 transition for an example of the large-rewrite path
+(`archive/2026-05-01-p28-gemini-background-deep-research.md` →
+`docs/superpowers/plans/2026-05-11-p28-gemini-deep-research-background.md`).

--- a/scripts/spike/CLAUDE.md
+++ b/scripts/spike/CLAUDE.md
@@ -1,0 +1,119 @@
+# Writing live-API spike scripts
+
+Spike scripts probe live provider APIs to validate plan assumptions
+before code is written. Live-API spend MUST be user-authorized.
+
+## Survival rule: write outputs DIRECTLY, never via tee
+
+Scripts dispatched by a subagent often outlive the dispatching agent
+(subagents have ~30 min wall budgets; spikes can take 60+ min). When
+the agent dies, the `tee` pipe dies with it, and `script.py | tee out.txt`
+loses ALL output even though the Python process keeps running.
+
+```bash
+# WRONG — output lost if subagent dies before script completes
+uv run scripts/spike/my_spike.py 2>&1 | tee research/_my_spike.txt
+
+# RIGHT — script writes its own log + JSON internally
+uv run scripts/spike/my_spike.py
+# inside the script:
+LOG = OUT_DIR / "_my_spike.txt"
+def log(msg): LOG.open("a").write(msg + "\n")
+```
+
+See the P28 Task 6b incident in `research/gemini-dr-api-spike-2026-05-11.md §6b`:
+~$5-7 of API spend lost across two attempts before pivoting to a
+surface-only probe.
+
+## Checkpoint intermediate state
+
+If a spike has multiple probes, write JSON state after EACH probe
+completes. A 60-min spike that crashes at minute 59 with no
+checkpointing loses everything:
+
+```python
+RESULTS = {}
+for probe_name, probe_fn in PROBES:
+    RESULTS[probe_name] = await probe_fn(client)
+    # Write checkpoint after EACH probe — survives mid-run termination.
+    OUT_JSON.write_text(json.dumps(RESULTS, indent=2, default=str))
+```
+
+## UV-shebang convention
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["google-genai>=1.74.0", "httpx"]
+# ///
+"""Brief description. Outputs to research/_my_spike.{json,txt}."""
+
+from __future__ import annotations
+import asyncio, json, os, sys
+from pathlib import Path
+```
+
+Make executable: `chmod +x scripts/spike/p<NN>/my_spike.py`.
+
+## File layout
+
+| Path | Purpose |
+|---|---|
+| `scripts/spike/p<NN>/spike_*.py` | The executable spike scripts |
+| `research/_<spike_name>.json` | Structured evidence (machine-readable) |
+| `research/_<spike_name>.txt` | Human-readable log (optional) |
+| `research/<topic>-api-spike-<DATE>.md` | Findings doc that interprets the evidence |
+
+Filename convention: `_dr_spike_<topic>.*` for raw evidence (leading
+underscore signals "raw data, not the writeup"). The findings doc has
+no underscore prefix.
+
+## Reproducibility headers
+
+Include in each JSON dump:
+
+```python
+{
+    "captured_at": datetime.now(tz=timezone.utc).isoformat(),
+    "script": Path(__file__).name,
+    "sdk_versions": {"google-genai": genai.__version__},  # if accessible
+    "inputs": {"prompt": PROMPT[:200], "agent": AGENT},
+    "results": [...],
+}
+```
+
+Lets a v1.1 maintainer re-run the script against a newer SDK and
+diff the findings.
+
+## Live-API spend awareness
+
+Estimate spend per probe upfront in the script's docstring:
+
+```python
+"""Cost: ~$2-5 for 3 probes against deep-research-preview-04-2026.
+
+User-authorize before running. Free tier is ineligible (DR is paid-only)."""
+```
+
+Surface the estimate to the user when the spike is queued in a plan
+task. Don't run paid spikes silently.
+
+## Parallel-subagent hygiene
+
+If another subagent is concurrently writing code in `src/` or `tests/`,
+spike subagents MUST use explicit `git add` paths:
+
+```bash
+# RIGHT — explicit paths, won't pick up the other subagent's WIP
+git add scripts/spike/p<NN>/my_spike.py research/_my_spike.* research/findings.md
+git commit -m "..."
+
+# WRONG — will pick up any uncommitted files in the worktree
+git add -A
+git commit -m "..."
+```
+
+Conventional Commits: spike commits use `chore(<scope>):` —
+`spike(<scope>):` is NOT in the allowed commitlint types and will be
+rejected.

--- a/src/doxa_research/providers/CLAUDE.md
+++ b/src/doxa_research/providers/CLAUDE.md
@@ -1,0 +1,248 @@
+# Provider implementation conventions
+
+Each provider class extends `ResearchProvider` (`base.py`). The conventions
+below were established by P26 (OpenAI), refined by P27 (Perplexity), and
+extended by P28 (Gemini). Future provider work should match.
+
+## Module-level constants
+
+```python
+_PROVIDER_NAME_<UPPER> = "<lower>"  # e.g. _PROVIDER_NAME_GEMINI = "gemini"
+```
+
+Used in every `ProviderError(_PROVIDER_NAME_<X>, ...)` raise. Never use
+string literals.
+
+## Shared helpers (in `_helpers.py`)
+
+| Helper | Purpose |
+|---|---|
+| `_invalid_key_thotherror(provider, settings_url)` | Consistent 401-with-pricing-URL error. Pass the provider's auth-key management URL. |
+| `render_sources_block(citations)` | Renders a `## Sources` markdown block from a list of `Citation` instances. Used by all providers' `get_result` paths. |
+| `debug_print_empty_response(response, *, provider_label)` | Verbose-mode dump for an unexpectedly empty response. |
+| `_extract_unsupported_param(message)` | Pulls a parameter name out of an "unsupported parameter X" SDK error message. |
+
+## Required methods (from `ResearchProvider` base contract)
+
+| Method | Notes |
+|---|---|
+| `submit(prompt, mode, system_prompt, verbose) -> str` | Returns a `job_id`. For immediate-only providers, response is cached for `get_result`. |
+| `check_status(job_id) -> dict[str, Any]` | Returns `{"status": "<thoth-status>", ...}`. Status values: `in_progress` / `completed` / `cancelled` / `transient_error` / `permanent_error` / `not_found`. May include `failure_type` discriminator. |
+| `get_result(job_id, verbose=False) -> str` | Renders the completed job as markdown. Empty string OK; never None. |
+| `cancel(job_id) -> dict[str, Any]` | Returns `{"status": "cancelled", ...}` on success. For 5xx errors, may include `"best_effort": True`. |
+| `reconnect(job_id) -> None` | Re-attaches to an existing job after process restart. Seeds `self.jobs[job_id]`. |
+| `list_models() -> list[dict[str, Any]]` | Returns models the provider exposes. May raise. |
+| `stream(prompt, mode, system_prompt, verbose) -> AsyncIterator[StreamEvent]` | Optional. Background-only providers may raise NotImplementedError; the runtime tolerates it. |
+
+## Kind-mismatch guard
+
+Call `self._validate_kind_for_model(mode)` at the TOP of `submit()` (and
+inside `stream()` if implemented). Raises `ModeKindMismatchError` BEFORE
+any HTTP attempt when `kind="immediate"` is dispatched against a
+background-only model.
+
+Hybrid-routing providers (currently only Gemini) put the check in BOTH
+the public router AND each `_immediate_*` / `_deep_research_*` sub-method.
+Idempotent, intentional — see Task 3 spec-review reasoning in
+`docs/superpowers/plans/2026-05-11-p28-gemini-deep-research-background.md`.
+
+## Internal-helper layout
+
+P27 convention: provider-specific helpers (citation formatters, retry
+predicates, parsers) live BELOW the provider class at module bottom.
+See `perplexity.py` for the canonical example.
+
+## Retry policy
+
+Tenacity decorator on `submit()` (and `_*_submit_with_retry` internal
+helpers) — 3 attempts, exponential 4-10s, filter by transient/timeout/
+connection only (never 4xx other than 429):
+
+```python
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+    retry=retry_if_exception(_is_retryable_<provider>_exception),
+    reraise=True,
+)
+```
+
+Each provider needs a `_is_retryable_<provider>_exception(exc)` predicate.
+
+## Error mapping
+
+`_map_<provider>_error(exc, model, verbose=False) -> ThothError`. Covers
+401/403/404/429/400/5xx + httpx network errors. Each branch returns a
+ThothError subclass with an actionable message. Mirror the 12-branch
+shape of `_map_openai_error` (in `openai.py`).
+
+For providers with private SDK exception modules (Gemini), add a
+try-import + duck-type fallback predicate at module top:
+
+```python
+try:
+    from google.genai._interactions import GeminiNextGenAPIClientError as _IExc
+    _HAS_IEXC = True
+except ImportError:
+    _HAS_IEXC = False
+    _IExc = None
+
+def _is_interactions_error(exc):
+    if _HAS_IEXC and isinstance(exc, _IExc):
+        return True
+    return type(exc).__module__.startswith("google.genai._") and hasattr(exc, "status_code")
+```
+
+## `self.jobs` schema
+
+```python
+self.jobs[job_id] = {
+    "kind": "immediate" | "deep_research",   # discriminator
+    "interaction_id": str,                   # DR only — same as job_id usually
+    "mode": str,
+    "model": str,
+    "submitted_at": float,                   # time.time()
+    # Immediate path only:
+    "response": <cached SDK response>,
+    "created_at": float,
+    # DR path only:
+    "last_status": str,
+    "last_interaction": <last get response>,
+    "cancel_requested": bool,
+    "reconnected_at": float,
+}
+```
+
+The `kind` discriminator is REQUIRED for hybrid-routing providers.
+Use `self.jobs.get(job_id, {}).get("kind") == "deep_research"` for the
+DR check (e.g. via a `_is_dr_job(job_id)` helper).
+
+## Hybrid routing (P28 Gemini delta — not P26/P27)
+
+When a provider supports BOTH immediate and background paths over
+DIFFERENT SDK methods, public `submit / check_status / get_result /
+cancel / reconnect` become 5-line routers that branch on
+`is_background_model(self.model)` and delegate to `_immediate_*`
+(P24 chat path) or `_deep_research_*` (P28 Interactions path).
+
+This is NOT the P26/P27 pattern — those route inside a single SDK
+method. The hybrid pattern is Gemini-specific because the Gemini DR
+API surface is entirely different from chat completion. Future
+cross-provider refactor (P29) should treat the divergence as
+intentional, not consolidation drift.
+
+---
+
+# Per-provider specifics
+
+## OpenAI (`openai.py`)
+
+| Topic | Notes |
+|---|---|
+| **SDK** | Official `openai` Python SDK. Auth-key URL: `https://platform.openai.com/api-keys`. |
+| **Background path** | `client.responses.create(model=..., input=..., background=True)` returns `resp_*` ID. Poll via `client.responses.retrieve(id)`. |
+| **Models** | `o3-deep-research`, `o4-mini-deep-research` (background). Standard chat models (immediate). |
+| **Error hierarchy** | Public via `openai.<ErrorClass>` (`AuthenticationError`, `RateLimitError`, etc.). No private-module quirk. |
+| **Citations** | On response output annotations. See `openai.py` `_render_sources` and the annotation extraction loop. |
+| **Mode-config support** | `max_tool_calls`, `code_interpreter`, `organization` all consumed. |
+| **Polling cadence** | 30s default (P26). |
+
+## Perplexity (`perplexity.py`)
+
+| Topic | Notes |
+|---|---|
+| **SDK** | OpenAI Python SDK in compatibility mode against `https://api.perplexity.ai` for sync. httpx directly for async DR jobs (`/async/chat/completions`). |
+| **DUAL-PATH ARCHITECTURE** | Sync path (`chat.completions`) AND async path (`async/chat/completions`). Two error mappers: `_map_perplexity_error` (sync) + `_map_perplexity_error_async`. |
+| **Models** | `sonar`, `sonar-pro` (immediate); `sonar-deep-research` (background). |
+| **`extra_body` namespace** | Perplexity-specific options live under `[modes.<X>.perplexity]` and forward to the SDK's `extra_body` (e.g. `web_search_options.search_context_size`). Modeled as `dict[str, Any]` in `config_schema.PerplexityConfig` — permissive to allow SDK evolution. |
+| **Think-tag parser** | `_ThinkStreamParser` handles `<think>...</think>` tags split across stream chunks. Reuse if any other provider emits the same pattern. |
+| **Citations** | `response.search_results` for async; inline for sync. See `_format_async_sources_block`. |
+| **Polling cadence** | 30s. |
+
+## Gemini (`gemini.py`)
+
+Substantial extra detail because P28 shipped recently and the API has
+non-obvious quirks.
+
+### SDK and surfaces
+
+| Topic | Notes |
+|---|---|
+| **SDK package** | `google-genai>=1.74.0`. Auth-key URL: `https://aistudio.google.com/app/apikey`. Tier: paid Tier 1+ required for Deep Research. |
+| **Immediate path** | `client.aio.models.generate_content[_stream](model=..., contents=..., config=...)`. P24's territory. |
+| **Background path (Deep Research)** | `client.aio.interactions.create(agent=..., input=..., background=True, store=True)`. P28's territory. ASYNC-ONLY surface (no sync equivalent). |
+| **Hybrid class** | `GeminiProvider` routes between immediate and DR based on `is_background_model(self.model)`. See "Hybrid routing" section above. |
+
+### Deep Research exception hierarchy (PRIVATE MODULE)
+
+DR exceptions live in **private** module `google.genai._interactions`:
+
+```
+GeminiNextGenAPIClientError  <-  Exception   (NOT inherited from google.genai.errors.APIError)
+  BadRequestError      (HTTP 400)
+  AuthenticationError  (HTTP 401)
+  PermissionDeniedError (HTTP 403)
+  NotFoundError        (HTTP 404)
+  RateLimitError       (HTTP 429)   (NOT named TooManyRequestsError)
+  InternalServerError  (HTTP 500)
+  APIConnectionError   (no status_code)
+  APITimeoutError      (no status_code)
+```
+
+**Important**:
+- `exc.status_code` is the int. `exc.code` is ALWAYS `None` for these.
+- Constructor is `(message: str, *, response: httpx.Response, body: object | None)`. NOT `(status_code=..., message=...)`.
+- The hierarchy does NOT inherit from `google.genai.errors.APIError`. Catch
+  via the `_is_interactions_error(exc)` predicate in `gemini.py`, NOT
+  `isinstance(exc, genai_errors.APIError)`.
+
+### Deep Research API quirks
+
+| Topic | Notes |
+|---|---|
+| **Required `create()` params** | `agent=<id>`, `background=True`, `store=True`. All three required. |
+| **`agent` parameter values (as of 2026-05-13)** | `deep-research-preview-04-2026` (fast, $1-3/task, P28 v1 default). `deep-research-max-preview-04-2026` ($3-7/task, deferred to successor project). `deep-research-pro-preview-12-2025` (legacy — STILL LISTED by live API; don't assume removed). |
+| **API methods on `client.aio.interactions`** | `create`, `get`, `cancel`, `delete`, `with_raw_response`, `with_streaming_response`. **NO `continue` / `resume` / `refetch` method** — `incomplete` interactions are terminal. |
+| **`previous_interaction_id`** | Conversation chaining only. NOT a refetch mechanism for incomplete runs. |
+| **Status enum (6 values, not 4)** | `Literal['in_progress', 'requires_action', 'completed', 'failed', 'cancelled', 'incomplete']`. v1 maps `requires_action` and `incomplete` via the `failure_type` discriminator (`"requires_action"` / `"permanent"`). |
+| **Citation extraction path** | `interaction.steps[N].content[0].annotations[]` where N is the first `model_output` step. **NOT** `interaction.outputs[-1].annotations[]` — `outputs` does not exist. Only the first model_output step carries annotations. |
+| **`URLCitation` shape** | `{type: 'url_citation', start_index: int, end_index: int, title: None (always), url: <Vertex AI grounding redirect URL>}`. `title` is always None. `url` is a redirect, not the source URL. |
+| **SDK-rendered Sources block** | The LAST step's `content[0].text` contains a markdown `[domain](redirect-url)` block. Parse it with `_parse_sdk_sources_block()` for domain titles since `URLCitation.title` is unusable. |
+| **Layered citation rendering** | (1) parse SDK Sources block for `{redirect_url: domain_title}`. (2) Bounded-concurrency HEAD-follow each redirect URL to get source URL. (3) Title-derivation chain: `parsed_sources.get → urlparse(source).netloc → URL`. (4) Dedupe by final URL. See `_resolve_dr_redirects` in `gemini.py`. |
+| **Polling cadence and timeout** | Schema-only in v1: `[providers.gemini].poll_interval = 10` and `.max_wait_minutes = 60`. Runtime still reads `[execution].poll_interval` (default 30s) and `.max_wait` (default 30min). Set `[execution].max_wait = 60` for DR users (upstream hard limit is 60 min). v1.1 will wire the per-provider override. |
+| **Retention windows** | Paid tier: 55 days. Free tier: 1 day (but DR is paid-only). `interactions.get()` on expired ID → `NotFoundError(404)` → mapped to "interaction expired" message via `_map_gemini_error`. |
+| **`is_background_model("deep-research-...")` returns True** | Substring match on "deep-research" (see `config.py`). Covers all three DR agent IDs. |
+| **Pricing (preview)** | Fast tier $1-3/task, max tier $3-7/task. Free tier ineligible. |
+
+### Cancel behavior (defensive)
+
+`client.aio.interactions.cancel(id)` exists. Behavior under load (e.g.
+overscoped prompt that triggers server-side capacity rejection) can
+return HTTP 500. v1 implementation treats 5xx as best-effort: returns
+`{"status": "cancelled", "best_effort": True}` so the runtime's SIGINT
+path completes cleanly. The actual server state surfaces on the next
+`check_status` poll.
+
+For post-restart `doxa cancel <op-id>` (when `self.jobs` is empty),
+the cancel path seeds a minimal jobs entry and attempts the upstream
+call directly — does NOT short-circuit to `not_found` for DR-shaped
+job IDs.
+
+### v1 deferred / open questions
+
+- `requires_action` trigger conditions — Task 6a spike found 0 of 3
+  probe configurations triggered it (tool=code_execution,
+  collaborative_planning, tool=file_search). v1 treats as
+  `permanent_error + failure_type=requires_action` with a useful
+  error message.
+- `incomplete` recoverability — NO recovery method on the SDK. v1
+  treats as `permanent_error + failure_type=permanent`.
+- Per-provider polling tunables — schema defined, runtime wiring v1.1.
+- Cancel re-verification — defensive 5xx impl ships; spike re-verify
+  deferred to v1.1.
+
+## Mock (`mock.py`)
+
+Synthetic provider for tests. No special conventions. Useful for
+exercising the polling loop / checkpoint state machine without API
+spend.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,100 @@
+# Testing conventions
+
+Root `CLAUDE.md` covers test-run commands (Fast Iteration Loop) and the
+real-API marker schedule. This file covers test-AUTHORING conventions that
+subagents otherwise re-derive from reading existing files.
+
+## Async test pattern
+
+This repo uses `def test_*(...)` with `asyncio.run(_inner_async())` —
+NOT `@pytest.mark.asyncio + async def`.
+
+```python
+def test_some_async_path(self, monkeypatch):
+    async def _run():
+        # ... async test body ...
+        result = await provider._deep_research_submit("prompt", "mode", None, False)
+        assert result.startswith("interactions/")
+    asyncio.run(_run())
+```
+
+Ratio in `tests/test_provider_gemini.py`: 25+ uses of `asyncio.run`,
+0 uses of `@pytest.mark.asyncio`. Match it when adding tests.
+Reason: avoids the `pytest-asyncio` plugin dep for a small async surface.
+
+## Mocking provider SDKs — the read-only-property gotcha
+
+Some SDKs (notably `google.genai`) expose `client.aio.<resource>` as a
+read-only `@property`. The naïve setter raises `AttributeError`:
+
+```python
+# WRONG — AttributeError: property 'interactions' has no setter
+provider.client.aio.interactions = MagicMock()
+
+# RIGHT — replace the entire client
+provider.client = MagicMock()
+provider.client.aio.interactions.create = AsyncMock(return_value=...)
+```
+
+This applies to Gemini's `client.aio.interactions`; verify case-by-case
+for other SDKs. The OpenAI Python SDK and the Perplexity OpenAI-compat
+client do NOT have this restriction.
+
+## Mocking provider exceptions — real constructors only
+
+Some provider SDKs use private exception modules with non-obvious
+constructors. For Gemini's Deep Research exceptions
+(`google.genai._interactions.{BadRequestError, NotFoundError, ...}`),
+the signature is:
+
+```python
+ExceptionClass(message: str, *, response: httpx.Response, body: object | None)
+# NOT (status_code=..., message=...)
+```
+
+Build a real `httpx.Request + Response` pair in test fixtures:
+
+```python
+req = httpx.Request("POST", "https://example.com")
+resp = httpx.Response(404, request=req)
+exc = NotFoundError("Interaction not found", response=resp, body=None)
+```
+
+If `tests/conftest.py` (or a future `tests/_helpers.py`) ever ships a
+`make_interactions_error(status_code, message)` builder, use it
+instead of constructing raw exceptions per-test.
+
+## File naming and location
+
+| Pattern | Purpose | Marker |
+|---|---|---|
+| `tests/test_provider_<name>.py` | Unit tests with monkeypatched SDK | (none — runs by default) |
+| `tests/test_vcr_<name>.py` | Cassette replay (when used) | (none) |
+| `tests/extended/test_<name>_real_workflows.py` | Live-API CLI workflow tests | `@pytest.mark.live_api` |
+| `tests/extended/test_model_kind_runtime.py` | Auto-iterates `KNOWN_MODELS`; covers drift for ALL providers | `@pytest.mark.extended` |
+
+Adding a new mode to `BUILTIN_MODES` / `KNOWN_MODELS` is auto-covered
+by the extended drift test — no per-mode test file needed.
+
+## Marker gating (recap)
+
+`pyproject.toml` sets `addopts = "-m 'not extended and not live_api'"`,
+so `live_api` and `extended` tests are deselected by default. They run
+only when invoked explicitly via `just test-extended` / `just test-live-api`
+or via the nightly / weekly GitHub workflows.
+
+`extended_slow` is a sub-marker for tests that take >1 min wall-time;
+opt in with `THOTH_EXTENDED_SLOW=1` (legacy env name) or via
+`pytest -m extended_slow`.
+
+## Long-running test budgets
+
+If a test calls `subprocess.run(...)` with `doxa ask --mode gemini_*_research`
+or another DR mode, set `timeout=20*60` minimum — Deep Research fast tier
+can take 5-15 minutes wall-clock; max tier longer.
+
+## Don't add VCR cassettes for Gemini in v1
+
+P24 chose `unittest.mock.patch`-based monkeypatching over VCR. P28 follows.
+VCR support is an open option for v1.1+ — don't add cassettes without
+the project owner's sign-off.


### PR DESCRIPTION
## Summary

Adds 4 sub-CLAUDE.md files in directories where conventions, SDK quirks, and process patterns have been repeatedly re-derived by subagents across recent project work (notably P28 Gemini Deep Research, P24 Gemini immediate, P26/P27 background providers).

Loaded contextually by Claude Code at directory level — no single conversation sees all of them, so total token cost is amortized across work.

## Files (593 lines total)

| Path | Lines | Focus |
|---|---|---|
| `tests/CLAUDE.md` | 100 | Async test pattern (`asyncio.run` not `@pytest.mark.asyncio`), SDK read-only-property gotcha, exception constructors, file naming, marker gating |
| `src/doxa_research/providers/CLAUDE.md` | 248 | Shared conventions (P26+P27 patterns) plus per-provider specifics for OpenAI, Perplexity, and (extensively) Gemini |
| `scripts/spike/CLAUDE.md` | 119 | Spike-script survival rules: write outputs directly (not via tee), checkpoint intermediate state, parallel-subagent hygiene |
| `docs/superpowers/plans/CLAUDE.md` | 126 | Plan-writing: stable-name cross-refs, renumbering technique, commitlint footer traps, allowed types |

## Motivation

A retrospective on the P28 session surfaced ~7 categories of repeated friction:

1. **Commitlint rejections** (5 retry cycles) — undocumented allowed types, 100-char limit, `#N` and trailing-colon footer traps
2. **`client.aio.interactions` read-only property** — 4+ subagents independently rediscovered the workaround
3. **`tee` output lost when subagent terminates** — ~\$5-7 API spend lost across 2 spike attempts
4. **SDK exception constructor signatures** — subagents copy-pasted spec templates that didn't match real SDK shape
5. **Plan cross-references drift after renumbering** — perl-regex renumber caught most but not all
6. **Test-style convention mismatch** — every test-writing subagent had to discover `asyncio.run()` vs `@pytest.mark.asyncio`
7. **Repeated SDK exception class discovery** — `google.genai._interactions` private module rediscovered by 2-3 subagents

These docs capture all of the above at the point in the tree where they're relevant. The Gemini-specific content in `src/doxa_research/providers/CLAUDE.md` is the heaviest — P28 just shipped, the API has the most quirks, and P29's upcoming arch review will hit the same surface.

## Test plan

- [x] All 4 files committed cleanly; pre-commit gate green
- [x] No code changes; doc-only
- [ ] Manual: open a test file under `tests/`, confirm Claude Code loads `tests/CLAUDE.md` automatically
- [ ] Manual: same for the provider, spike, and plans directories
- [ ] Future P29 or v1.1 work confirms these reduce subagent re-derivation

## Followups (not in this PR)

- Could ship a `tests/conftest.py` fixture/helper for `mocked_gemini_provider()` and `make_interactions_error(status_code, message)` to back what `tests/CLAUDE.md` describes. Mentioned as a forward-pointer in the file.
- Could trim or fold the Gemini section into a separate `src/doxa_research/providers/CLAUDE-gemini.md` if reviewers find the per-provider sub-sections too long to load globally. Current single-file approach matches how P26/P27 conventions are already co-located.