### PR TITLE
ci: migrate release-please to RELEASE_PLEASE_CLIENT_ID

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,57 @@
+# actionlint configuration
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# actionlint v1.7.12 (latest as of 2026-06) ships with stale bundled
+# metadata for `actions/create-github-app-token@v3`. The action accepts
+# a `client-id` input (the modern, preferred auth path; `app-id` is
+# deprecated), but actionlint's schema still only knows about `app-id`.
+#
+# As a result, every workflow that uses the modern `client-id` form
+# trips TWO false positives from actionlint's `action` check:
+#
+#   1. `input "client-id" is not defined in action
+#      "actions/create-github-app-token@v3"`
+#   2. `missing input "app-id" which is required by action
+#      "actions/create-github-app-token@v3"`
+#
+# Both are the same root-cause stale-metadata bug.
+#
+# UPSTREAM TRACKING
+# -----------------
+# Fixes are in flight upstream but not yet released:
+#   - rhysd/actionlint#652 (PR)
+#   - rhysd/actionlint#668 (PR)
+#   - rhysd/actionlint#648 (issue)
+#   - rhysd/actionlint#669 (issue)
+#
+# EXPIRATION
+# ----------
+# DELETE THIS FILE once a newer actionlint release ships with updated
+# bundled metadata for `actions/create-github-app-token@v3`'s
+# `client-id` input. To check: run `actionlint` against
+# `.github/workflows/release-please.yml` with the new version, with
+# this file removed — it should exit 0.
+#
+# SCOPE
+# -----
+# The suppression is narrowly scoped to the workflow that uses
+# `create-github-app-token@v3` with `client-id`. All other actionlint
+# checks remain active, both globally and on this file.
+
+self-hosted-runner:
+  labels: []
+
+config-variables: null
+
+paths:
+  .github/workflows/release-please.yml:
+    ignore:
+      # False positive: action accepts `client-id` (stale actionlint schema).
+      - >-
+          input "client-id" is not defined in action
+          "actions/create-github-app-token@v3"
+      # False positive: `app-id` is only required when `client-id` is absent.
+      - >-
+          missing input "app-id" which is required by action
+          "actions/create-github-app-token@v3"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,12 +33,13 @@ jobs:
       # push created by release-please retriggers publish.yml. The default
       # GITHUB_TOKEN cannot retrigger other push-triggered workflows. See
       # RELEASE.md → "GitHub App setup for release-please" for one-time
-      # configuration (App ID as repo variable, private key as secret).
+      # configuration (Client ID and private key both stored as repo
+      # secrets).
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5
         id: release
@@ -68,8 +69,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6.0.2
         with:


### PR DESCRIPTION
## Summary

Bring this repo in line with the org-wide migration from `actions/create-github-app-token@v3`'s deprecated `app-id` input to the modern `client-id` input. Sibling `smorin*/` repos were migrated earlier; this one was missed and surfaced by an org-wide search.

It's currently working on the legacy path but would silently break if/when the legacy secrets are removed.

### Changes
- Workflow auth (both `release-please` and `sync-uv-lock` jobs): `client-id` instead of `app-id` (deprecated).
- Secret source: `secrets.RELEASE_PLEASE_CLIENT_ID` (was `vars.RELEASE_PLEASE_APP_ID`, a repo variable).
- Private key: renamed from `RELEASE_PLEASE_APP_PRIVATE_KEY` to `RELEASE_PLEASE_PRIVATE_KEY` to match the convention used by the other migrated repos.
- Added `.github/actionlint.yaml` suppressing the two `client-id` false positives caused by actionlint's stale bundled schema for `actions/create-github-app-token@v3` (same workaround as `py-launch-blueprint`, removable once actionlint releases a fix).

Secrets `RELEASE_PLEASE_CLIENT_ID` + `RELEASE_PLEASE_PRIVATE_KEY` already provisioned via the `repo-secrets` skill from 1Password (`smorin-org` refs).

## Test plan

- [ ] CI green on this PR (lefthook hooks already ran locally and pass).
- [ ] After merge: trigger `release-please.yml` on `main` and confirm the `create-github-app-token` step shows `client-id` populated with no deprecation warning.
- [ ] After verification: delete legacy `vars.RELEASE_PLEASE_APP_ID` + `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use repository secrets for authentication.
  * Suppressed recurring false positive warnings in CI linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->