### PR TITLE
refactor(version): derive __version__ from installed package metadata

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,10 +9,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        "src/doxa_research/__init__.py"
-      ]
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "changelog-sections": [

--- a/src/doxa_research/__init__.py
+++ b/src/doxa_research/__init__.py
@@ -1,5 +1,20 @@
 """Doxa Research - AI-Powered Research Assistant."""
 
-__version__ = "3.1.0"  # x-release-please-version
+from importlib import metadata
+
+try:
+    __version__ = metadata.version("doxa-research")
+except metadata.PackageNotFoundError:
+    # Fallback for non-installed development trees. The `./doxa` launcher
+    # uses `uv run --script` with src/ on sys.path but does NOT install the
+    # doxa-research package, so metadata lookup fails there. Read the SSOT
+    # (pyproject.toml [project].version) directly. Production wheels never
+    # hit this branch — their .dist-info/METADATA is populated by uv_build.
+    import tomllib
+    from pathlib import Path
+
+    _pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    __version__ = tomllib.loads(_pyproject.read_text())["project"]["version"]
+
 __copyright__ = "Copyright (C) 2025-2026 Steve Morin"
 __license__ = "AGPL-3.0-or-later"

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import tomllib
+from importlib import metadata
 from pathlib import Path
 
 from doxa_research import __version__
@@ -33,10 +34,27 @@ def test_manifest_matches_pyproject() -> None:
     assert _manifest_version() == _pyproject_version()
 
 
-def test_installed_version_matches_pyproject() -> None:
-    """``__version__`` is derived from installed package metadata.
+def test_installed_metadata_matches_pyproject() -> None:
+    """The distribution-metadata path (the canonical install-time source) matches.
 
-    Requires a synced environment (``uv sync``); the version baked into the
-    installed distribution must match the source-of-truth in pyproject.toml.
+    Uses ``importlib.metadata`` DIRECTLY — not the ``__version__`` import —
+    because ``__init__.py`` has a ``pyproject.toml`` fallback for the
+    ``./doxa`` dev launcher. That fallback would mask a broken install
+    (a missing ``.dist-info/METADATA``, a rename gone wrong, a uv_build
+    regression) by silently substituting the pyproject value. Bypassing
+    the fallback here means a real metadata mismatch is caught loudly.
+    Requires a synced env (``uv sync``).
+    """
+    assert metadata.version("doxa-research") == _pyproject_version()
+
+
+def test_dunder_version_matches_pyproject() -> None:
+    """``doxa_research.__version__`` (consumed by docs/CLI) matches.
+
+    Exercises the fully-resolved value users see — either via
+    ``importlib.metadata`` (installed wheels, uv-managed envs) or via the
+    ``pyproject.toml`` fallback (``./doxa`` launcher). Both branches read
+    the same SSOT, so this test passes regardless of install state; pair
+    it with ``test_installed_metadata_matches_pyproject`` for full coverage.
     """
     assert __version__ == _pyproject_version()

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -1,0 +1,42 @@
+"""Guard that the project version stays single-sourced.
+
+``pyproject.toml`` ``[project] version`` is the single source of truth.
+release-please bumps it together with ``.release-please-manifest.json``, and
+``doxa_research.__version__`` is derived from the installed package metadata
+(populated by ``uv_build`` at build time). These tests fail if any of those
+copies drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+from doxa_research import __version__
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pyproject_version() -> str:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def _manifest_version() -> str:
+    data = json.loads((ROOT / ".release-please-manifest.json").read_text())
+    return data["."]
+
+
+def test_manifest_matches_pyproject() -> None:
+    """release-please bumps both; they must never diverge."""
+    assert _manifest_version() == _pyproject_version()
+
+
+def test_installed_version_matches_pyproject() -> None:
+    """``__version__`` is derived from installed package metadata.
+
+    Requires a synced environment (``uv sync``); the version baked into the
+    installed distribution must match the source-of-truth in pyproject.toml.
+    """
+    assert __version__ == _pyproject_version()


### PR DESCRIPTION
## Summary
Switches `doxa_research.__version__` from a literal bumped at release time to a value derived at import time via `importlib.metadata`. The SSOT (`pyproject.toml [project].version`, bumped by release-please) is unchanged; only the surface in Python code changes.

```diff
 """Doxa Research - AI-Powered Research Assistant."""

-__version__ = "3.1.0"  # x-release-please-version
+from importlib import metadata
+
+try:
+    __version__ = metadata.version("doxa-research")
+except metadata.PackageNotFoundError:
+    # Fallback: read pyproject.toml directly. Fires only in non-installed
+    # dev trees (./doxa uses `uv run --script` which puts src/ on sys.path
+    # without installing the package). Production wheels never hit it.
+    import tomllib
+    from pathlib import Path
+    _pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    __version__ = tomllib.loads(_pyproject.read_text())["project"]["version"]
```

`release-please-config.json`:
```diff
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        "src/doxa_research/__init__.py"
-      ]
+      "changelog-path": "CHANGELOG.md"
```

## Why this beats the marker-comment pattern

| | before | after |
|---|---|---|
| Files release-please touches for version | 2 (`pyproject.toml` + `__init__.py`) | 1 (`pyproject.toml`) |
| `extra-files` entries | 1 | 0 |
| Marker comment maintenance | must survive refactors forever | none |
| Drift risk window | between bump-commit and any rebuild, if release-please's regex missed | none — derived at import |
| Test coverage for drift | none | 2 tests in `tests/meta/test_version_consistency.py` |

Mirrors the pattern py-launch-blueprint uses, with one local adaptation.

## The local adaptation: pyproject.toml fallback

plbp can use a bare `__version__ = metadata.version(pkg)` because every entry point installs the package first. doxa-research's `./doxa` launcher does NOT — it uses `uv run --script` (PEP 723 inline deps) with `src/` added to `sys.path` manually, so the doxa-research package itself is never installed in the ephemeral env. `metadata.version("doxa-research")` raises `PackageNotFoundError` there.

Verified empirically: without the fallback, all 75 `./doxa_test -r --provider mock` tests fail at import. With the fallback, all 75 pass.

The fallback is honest about *why* it exists (comment in the file) and reads the same SSOT (`pyproject.toml [project].version`) via `tomllib`, so there's no second authority — both branches arrive at the same answer.

## Test plan
- [x] `uv run python -c "from doxa_research import __version__; print(__version__)"` → `3.1.0` (installed path)
- [x] `./doxa_test -r --provider mock --skip-interactive` → `Passed: 75, Failed: 0` (fallback path via ./doxa)
- [x] `uv run pytest tests/meta/ -v` → 2 passed (manifest matches pyproject; installed __version__ matches pyproject)
- [x] Pre-commit + pre-push hooks pass
- [ ] CI green
- [ ] Confirm the next release-please-cut PR no longer touches `src/doxa_research/__init__.py` (only `pyproject.toml`, `.release-please-manifest.json`, and `CHANGELOG.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version management to dynamically source version information from installed package metadata, with fallback support for development environments.
  * Added comprehensive automated testing to ensure version consistency is maintained across package metadata, configuration files, and the installed package.
  * Updated release configuration settings to streamline the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->