### PR TITLE
chore(release-pipeline): harden commitlint + release-please + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     labels:
       - "dependencies"
 
+    # Route dependency bumps to the `Dependencies` CHANGELOG section by
+    # using the `deps` type prefix. Without this, dependabot defaults to
+    # `chore(deps): ...`, which release-please buckets under hidden
+    # `chore` — every dependency bump silently disappears from CHANGELOG.
+    # See release-please-config.json `changelog-sections` for the routing.
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
     # Wait 3 days after a release before opening a PR. Buffer against
     # the "bad release retracted within hours" pattern that hits major
     # libraries like openai or pydantic.
@@ -103,6 +112,11 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+
+    # See pip ecosystem above for rationale.
+    commit-message:
+      prefix: "deps"
+      include: "scope"
 
     cooldown:
       default-days: 3

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,8 +16,20 @@ concurrency:
   group: commitlint-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Per-author split: humans get the strict config (200-char body/footer caps);
+# dependabot gets the line-length rules disabled (it embeds long release-note
+# URLs that can't be wrapped — see commitlint.dependabot.config.mjs).
+#
+# Selection is on github.event.pull_request.user.login (the PR author),
+# NOT github.actor (which changes per-push and would mis-route after a
+# human pushes a merge commit into a bot-opened PR).
+#
+# The `if:` expressions use a known-vocabulary GitHub context field
+# (user.login) for equality comparison — no shell interpolation, safe.
 jobs:
-  commitlint:
+  commitlint-humans:
+    name: commitlint (humans)
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -26,3 +38,15 @@ jobs:
       - uses: wagoid/commitlint-github-action@v6
         with:
           configFile: commitlint.config.mjs
+
+  commitlint-dependabot:
+    name: commitlint (dependabot)
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.dependabot.config.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ API references cache at `planning/references.md`.
 
 ## Git Best Practices
 
-**Conventional Commits enforced.** Every commit message: `<type>[scope]: <subject>`. Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `ci`, `chore`, `build`, `style`, `revert`. Use `feat!:` or `BREAKING CHANGE:` footer for major bumps.
+**Conventional Commits enforced.** Every commit message: `<type>[scope]: <subject>`. Allowed types: `feat`, `fix`, `perf`, `refactor`, `deps`, `docs`, `test`, `ci`, `chore`, `build`, `style`, `revert`. Use `feat!:` or `BREAKING CHANGE:` footer for major bumps. `deps` is reserved for dependabot bumps (configured via `.github/dependabot.yml`); humans use `chore` for routine maintenance.
 
 **Releases automated by release-please.** Don't hand-edit `pyproject.toml`, `src/doxa_research/__init__.py`, `CHANGELOG.md`, or `.release-please-manifest.json` versions. Land conventional commits on `main` → release-please opens a Release PR → merging tags `vX.Y.Z` and triggers `publish.yml`. See `RELEASE.md`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,7 +96,7 @@ just install-dev   # uv sync + bun install + lefthook install + gitleaks
 make env-check   # checks uv, python3, just, bun
 ```
 
-**Commit message format:** all commits must follow [Conventional Commits](https://www.conventionalcommits.org/). The local `commit-msg` hook (lefthook) and the `commitlint` CI job both enforce this. Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `ci`, `chore`, `build`, `style`, `revert`.
+**Commit message format:** all commits must follow [Conventional Commits](https://www.conventionalcommits.org/). The local `commit-msg` hook (lefthook) and the `commitlint` CI job both enforce this. Allowed types: `feat`, `fix`, `perf`, `refactor`, `deps`, `docs`, `test`, `ci`, `chore`, `build`, `style`, `revert`. `deps` is reserved for dependabot bumps (auto-generated via `.github/dependabot.yml`'s `commit-message: prefix: deps` block) and routes to the `Dependencies` CHANGELOG section; humans use `chore` for routine maintenance.
 
 ---
 
@@ -110,7 +110,7 @@ Versions are bumped **automatically** by release-please from conventional-commit
 |----------------|------|
 | `feat!:` or `BREAKING CHANGE:` footer | `MAJOR` |
 | `feat:` | `MINOR` |
-| `fix:`, `perf:`, `refactor:`, `chore:`, `docs:`, `ci:`, `test:`, etc. | `PATCH` |
+| `fix:`, `perf:`, `refactor:`, `deps:`, `chore:`, `docs:`, `ci:`, `test:`, etc. | `PATCH` |
 
 You do **not** edit `pyproject.toml` or `src/doxa_research/__init__.py` version fields directly. release-please updates them in the Release PR.
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -20,6 +20,7 @@ export default {
         'fix',
         'perf',
         'refactor',
+        'deps',
         'docs',
         'test',
         'ci',
@@ -31,7 +32,14 @@ export default {
     ],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
+    // Header stays strict — titles should be tight for `git log --oneline`.
     'header-max-length': [2, 'always', 100],
+    // Body/footer raised from the inherited 100-char default to 200. Conventional
+    // commits routinely reference long permalinks, GitHub compare URLs, and
+    // `BREAKING CHANGE:` footers that can't be wrapped. 200 still catches genuinely
+    // unbounded paragraphs.
+    'body-max-line-length': [2, 'always', 200],
+    'footer-max-line-length': [2, 'always', 200],
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
   },

--- a/commitlint.dependabot.config.mjs
+++ b/commitlint.dependabot.config.mjs
@@ -41,9 +41,11 @@ export default {
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'header-max-length': [2, 'always', 100],
-    // Disable line-length caps for dependabot — see header comment.
-    'body-max-line-length': [0, 'always'],
-    'footer-max-line-length': [0, 'always'],
+    // Disable line-length caps for dependabot — see header comment. `[0]` is
+    // commitlint's canonical "disabled" form; the second argument is omitted
+    // because severity 0 short-circuits before the option is read.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
   },

--- a/commitlint.dependabot.config.mjs
+++ b/commitlint.dependabot.config.mjs
@@ -1,0 +1,50 @@
+// commitlint config for dependabot-authored PRs.
+//
+// Dependabot's body content is auto-generated from upstream release notes
+// and embeds full GitHub compare URLs, changelog links, and dep-tree
+// tables that routinely exceed the 200-char cap used for human commits.
+// Dependabot exposes no knob to wrap or reformat body content
+// (`commit-message:` only controls prefix/scope on the subject line).
+//
+// Trade-off: dependabot commits must still be valid conventional commits
+// (type, scope, subject) — only the line-length checks are relaxed. The
+// type-enum is inlined here (rather than imported from
+// commitlint.config.mjs) to keep this file self-contained the same way
+// commitlint.config.mjs is, so it works in any worktree without a
+// per-worktree `node_modules`.
+//
+// Per-author selection happens in `.github/workflows/commitlint.yml` via
+// `github.event.pull_request.user.login`.
+
+export default {
+  rules: {
+    'type-empty': [2, 'never'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'deps',
+        'docs',
+        'test',
+        'ci',
+        'chore',
+        'build',
+        'style',
+        'revert',
+      ],
+    ],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'header-max-length': [2, 'always', 100],
+    // Disable line-length caps for dependabot — see header comment.
+    'body-max-line-length': [0, 'always'],
+    'footer-max-line-length': [0, 'always'],
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [2, 'always'],
+  },
+};

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "229962c8be86ffcc636a0c53d50509267bdb5ac2",
   "release-type": "python",
   "pull-request-title-pattern": "chore(release): publish v${version} — review and merge to ship to PyPI",
   "packages": {
@@ -18,11 +19,12 @@
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },
+    { "type": "deps",     "section": "Dependencies" },
     { "type": "perf",     "section": "Performance" },
     { "type": "refactor", "section": "Refactoring" },
     { "type": "docs",     "section": "Documentation" },
-    { "type": "ci",       "section": "CI/CD" },
-    { "type": "test",     "section": "Testing" },
+    { "type": "ci",       "section": "CI/CD",        "hidden": true },
+    { "type": "test",     "section": "Testing",      "hidden": true },
     { "type": "chore",    "section": "Miscellaneous", "hidden": true }
   ]
 }


### PR DESCRIPTION
## Summary
Bundles five small improvements to the release pipeline. Each is independent; bundled because they share intent (CHANGELOG hygiene + commitlint robustness + dependabot routing).

## 1. Per-author commitlint split

`.github/workflows/commitlint.yml` is now two jobs gated on PR author:

- `commitlint-humans` (`user.login != 'dependabot[bot]'`)
- `commitlint-dependabot` (`user.login == 'dependabot[bot]'`)

Each uses a separate config. Humans get the strict caps (header 100, body/footer 200). Dependabot gets line-length rules disabled — dependabot embeds release-notes URLs and dep-tree tables that exceed 200 chars and can't be wrapped (no dependabot knob to do so).

Selector uses `github.event.pull_request.user.login` (PR author), NOT `github.actor` — `github.actor` changes per-push and would mis-route after a human pushes a merge commit into a bot-opened PR.

## 2. Raise body/footer caps 100 → 200

`commitlint.config.mjs`:
```diff
+'body-max-line-length':   [2, 'always', 200],
+'footer-max-line-length': [2, 'always', 200],
```

The inherited 100-char default was already biting in practice — long permalinks, GitHub compare URLs, signed-off-by lines, and `BREAKING CHANGE:` footers routinely cross 100. 200 still catches genuinely unbounded paragraphs. Header cap stays at 100 — titles should remain tight for `git log --oneline`.

## 3. Add `bootstrap-sha`

`release-please-config.json`:
```diff
+"bootstrap-sha": "229962c8be86ffcc636a0c53d50509267bdb5ac2",
```

(v3.0.1 commit — the earliest v-prefixed release.) Defensive backstop: if `.release-please-manifest.json` is ever deleted, corrupted, or reset, release-please uses `bootstrap-sha` as its scan floor instead of walking back to repo genesis (which would resurrect every pre-conventional-commit historical change into one massive release PR).

Costs nothing in normal operation — the manifest is the primary source of truth.

## 4. Hide `ci`/`test` sections in CHANGELOG

```diff
-{ "type": "ci",   "section": "CI/CD" },
-{ "type": "test", "section": "Testing" },
+{ "type": "ci",   "section": "CI/CD",   "hidden": true },
+{ "type": "test", "section": "Testing", "hidden": true },
```

Looking at recent `CHANGELOG.md`, 6 of the last ~18 auto-generated entries (33%) were CI/CD or Testing — equal real-estate to actual Bug Fixes. For a tool published to PyPI, the user audience cares about behavior changes; CI/test commits still bump the patch version (audit trail preserved) but no longer surface as sections.

Existing CHANGELOG entries are NOT retroactively rewritten — release-please only affects future releases.

## 5. Route dependabot commits to a `Dependencies` section

Four-part change:

- `commitlint.config.mjs` `type-enum`: add `deps`
- `commitlint.dependabot.config.mjs` (new): same enum, line rules relaxed (used by job from rec #1)
- `release-please-config.json` `changelog-sections`: add `{ "type": "deps", "section": "Dependencies" }`
- `.github/dependabot.yml`: each ecosystem (pip + github-actions) gets `commit-message: { prefix: "deps", include: "scope" }`

**Before**: dependabot emitted `chore(deps): bump …`, which routes to the hidden `chore` bucket. Every dependency bump silently disappeared from the CHANGELOG.

**After**: dependabot emits `deps(pip): bump …`, which routes to the new `Dependencies` section.

Why both parts are required: just adding `deps` to release-please does nothing if dependabot still says `chore(deps):` — release-please reads the leading type token. The two changes are paired.

Security audit story: a CVE patch delivered via dependabot now has a visible CHANGELOG line.

## Test plan
- [x] JSON config validates
- [x] Workflow YAML passes yamllint
- [x] Pre-commit + pre-push hooks pass (gitleaks, codespell, editorconfig, ruff, ty, bandit, yamllint, test)
- [x] The new commitlint config exercises itself on this commit (body lines exceed 100 chars in places — proves the 200 cap is taking effect)
- [ ] CI green
- [ ] Confirm a future dependabot PR uses `deps(...)` prefix
- [ ] Confirm a future release-please PR omits `### CI/CD` and `### Testing`