### PR TITLE
chore(dependabot): drop `include: scope` to remove redundant `deps(deps):` prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,13 @@ updates:
     # `chore(deps): ...`, which release-please buckets under hidden
     # `chore` — every dependency bump silently disappears from CHANGELOG.
     # See release-please-config.json `changelog-sections` for the routing.
+    #
+    # `include: scope` is intentionally omitted — dependabot's default
+    # scope is `deps`, which produced redundant `deps(deps): bump …`
+    # subjects. Without it, commits read `deps: bump click from 8.4.0…`,
+    # carrying the same routing info without the duplicate token.
     commit-message:
       prefix: "deps"
-      include: "scope"
 
     # Wait 3 days after a release before opening a PR. Buffer against
     # the "bad release retracted within hours" pattern that hits major
@@ -113,10 +117,9 @@ updates:
       - "dependencies"
       - "github-actions"
 
-    # See pip ecosystem above for rationale.
+    # See pip ecosystem above for rationale (prefix + omitted scope).
     commit-message:
       prefix: "deps"
-      include: "scope"
 
     cooldown:
       default-days: 3


### PR DESCRIPTION
## Summary
Follow-up to #107. After dependabot started using the new `deps` prefix via `commit-message: { prefix: "deps", include: "scope" }`, commits came out as:

```
deps(deps): bump click from 8.4.0 to 8.4.1
deps(deps): bump the openai-stack group across 1 directory with 2 updates
```

The `(deps)` scope is dependabot's default and adds no information beyond what the `deps:` type already carries. Dropping `include: scope` cleans up the subject:

```
deps: bump click from 8.4.0 to 8.4.1
deps: bump the openai-stack group across 1 directory with 2 updates
```

```diff
 commit-message:
   prefix: "deps"
-  include: "scope"
```

(applied to both `pip` and `github-actions` ecosystem blocks)

## Why it's safe

Release-please routes on the leading type token, which is still `deps` — the `Dependencies` CHANGELOG section keeps receiving these commits. Pure cosmetic change to the subject form.

## Inline comment

Added a short YAML comment explaining the intent so a future maintainer doesn't re-add `include: scope` thinking it's a missing best-practice.

## Test plan
- [x] yamllint passes
- [x] Pre-commit + commit-msg hooks pass
- [ ] CI green
- [ ] After merge, the next dependabot run produces `deps:` (no inner scope)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to optimize commit message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->